### PR TITLE
Add tests to manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
-include LICENSE *.rst 
+include LICENSE *.rst
+recursive-include tests *.py


### PR DESCRIPTION
I need tests to build the RPM. Looks like they got dropped from the dist tarball when the tests directory was moved.