### PR TITLE
Fix example for str.rjust(20, '_')

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -39,7 +39,7 @@ output length is wrong::
     5
 
     >>> print('コンニチハ'.rjust(20, '_'))
-    _____コンニチハ
+    _______________コンニチハ
 
 By defining our own "rjust" function that uses wcwidth, we can correct this::
 


### PR DESCRIPTION
The example currently shown is for `print('コンニチハ'.rjust(10, '_'))` :confused: