### PR TITLE
Switch to using importlib.metadata

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,7 +1,10 @@
 # coding: utf-8
 """Core tests for wcwidth module."""
 # 3rd party
-import pkg_resources
+try:
+    import importlib.metadata as importmeta
+except ImportError:
+    import importlib_metadata as importmeta
 
 # local
 import wcwidth
@@ -10,7 +13,7 @@ import wcwidth
 def test_package_version():
     """wcwidth.__version__ is expected value."""
     # given,
-    expected = pkg_resources.get_distribution('wcwidth').version
+    expected = importmeta.version('wcwidth')
 
     # exercise,
     result = wcwidth.__version__

--- a/tests/test_ucslevel.py
+++ b/tests/test_ucslevel.py
@@ -5,7 +5,6 @@ import warnings
 
 # 3rd party
 import pytest
-import pkg_resources
 
 # local
 import wcwidth

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ skip_missing_interpreters = true
 [testenv]
 deps = pytest==4.6.10
        pytest-cov==2.8.1
+       importlib_metadata
 commands = {envpython} -m pytest --cov-config={toxinidir}/tox.ini {posargs:\
              --strict --verbose \
              --junit-xml=.tox/results.{envname}.xml \

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ skip_missing_interpreters = true
 [testenv]
 deps = pytest==4.6.10
        pytest-cov==2.8.1
-       importlib_metadata
+       importlib_metadata; python_version < '3.8'
 commands = {envpython} -m pytest --cov-config={toxinidir}/tox.ini {posargs:\
              --strict --verbose \
              --junit-xml=.tox/results.{envname}.xml \


### PR DESCRIPTION
pkg_resources is a little heavyweight, and has some rather glaring
shortcomings for checking the metadata of an install Python package.
importlib.metadata is contained in the standard library (as of 3.8), and
provides a much nicer interface. Switch to using it, falling back to
importlib_metadata if the Python version is too old.