### PR TITLE
Fix typos

### DIFF
--- a/bin/new-wide-by-version.py
+++ b/bin/new-wide-by-version.py
@@ -11,7 +11,7 @@ For example::
         ...
 
 Means that chr(12752) through chr(12754) are new WIDE values
-for Unicode vesion 5.0.0, and were not WIDE values for the
+for Unicode version 5.0.0, and were not WIDE values for the
 previous version (4.1.0).
 """
 # std imports

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2,7 +2,7 @@
 Public API
 ==========
 
-This package follows SEMVER_ rules for version, therefor, for all of the
+This package follows SEMVER_ rules for version, therefore, for all of the
 given functions signatures, at example version 1.1.1, you may use version
 dependency ``>=1.1.1,<2.0`` for forward compatibility of future wcwidth
 versions.

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -8,7 +8,7 @@ This library is mainly for CLI programs that carefully produce output for
 Terminals, or make pretend to be an emulator.
 
 **Problem Statement**: The printable length of *most* strings are equal to the
-number of cells they occupy on the screen ``1 charater : 1 cell``.  However,
+number of cells they occupy on the screen ``1 character : 1 cell``.  However,
 there are categories of characters that *occupy 2 cells* (full-wide), and
 others that *occupy 0* cells (zero-width).
 


### PR DESCRIPTION
Found via `codespell -L rever,abov,ue,doub,oclock`