### PR TITLE
Fix "Specification" link in README

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -219,7 +219,7 @@ History
 0.2.9 *2023-10-30*
   * **Bugfix** zero-width characters used in Emoji ZWJ sequences, Balinese,
     Jamo, Devanagari, Tamil, Kannada and others (`PR #91`_).
-  * **Updated** to include `Specification <Specification_from_pypi>`_ of
+  * **Updated** to include `Specification <Specification_from_pypi_>`_ of
     character measurements.
 
 0.2.8 *2023-09-30*


### PR DESCRIPTION
The "Specification" link in the "History" section of the README is currently formatted incorrectly; there needs to be an underscore before the closing angle bracket in order for it to be parsed as an embedded alias.  Without the underscore, the link goes to the URL "Specification_from_pypi", which does not exist.