### PR TITLE
Include test data in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,4 @@ include requirements-*.in requirements-*.txt
 recursive-include bin *.py
 recursive-include code_templates *.j2
 recursive-include docs *.py *.rst requirements.txt
+recursive-include tests *.txt


### PR DESCRIPTION
Explicitly include test data files (`*.txt`) in sdist archives. Otherwise, only test Python files are included and the test suite fails because of missing data files.