### PR TITLE
Fix KeyError in bin/wcwidth-browser for combining

### DIFF
--- a/bin/wcwidth-browser.py
+++ b/bin/wcwidth-browser.py
@@ -116,7 +116,7 @@ class WcCombinedCharacterGenerator(object):
         """
         self.characters = []
         letters_o = ('o' * width)
-        for (begin, end) in ZERO_WIDTH[unicode_version]:
+        for (begin, end) in ZERO_WIDTH[_wcmatch_version(unicode_version)]:
             for val in [_val for _val in
                         range(begin, end + 1)
                         if _val <= LIMIT_UCS]:


### PR DESCRIPTION
Resolve KeyError when launching wcwidth-browser.py
with default unicode_version of 'auto', then pressing
'c' (for combining characters)::

      File "/Users/jq/Code/wcwidth/bin/wcwidth-browser.py", line 120, in __init__
        for (begin, end) in ZERO_WIDTH[unicode_version]:
                            ~~~~~~~~~~^^^^^^^^^^^^^^^^^
    KeyError: 'auto'
