### PR TITLE
Remove unavailable CPython 3.7 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,6 @@ jobs:
           - windows-latest
           - macos-latest
         python-version:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
@@ -52,8 +51,6 @@ jobs:
             container: python:2.7-buster
             python-version: "2.7"
         exclude:
-          - os: macos-latest
-            python-version: "3.7"
           - os: macos-latest
             python-version: "pypy-3.7"
 


### PR DESCRIPTION
Python 3.7 is end-of-life since [2023-06-27](https://devguide.python.org/versions/) and it's no longer available on GitHub Actions:

```
  Version ~3.7.0-0 was not found in the local cache
  Error: The version '3.7' with architecture 'x64' was not found for Ubuntu 24.04.
  The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
```

https://github.com/jquast/wcwidth/actions/runs/15637613097/job/44056758485?pr=117

Let's remove it from the CI.

I recommend dropping support for it as well, but this is a minimal change to try and get the CI back to green.