### PR TITLE
strip_sequences() performance increase and esc change

### DIFF
--- a/tests/test_clip.py
+++ b/tests/test_clip.py
@@ -22,8 +22,8 @@ STRIP_SEQUENCES_CASES = [
     ('\x1b[31m中文\x1b[0m', '中文'),
     ('\x1b[1m\U0001F468\u200D\U0001F469\u200D\U0001F467\x1b[0m',
      '\U0001F468\u200D\U0001F469\u200D\U0001F467'),
-    ('\x1b', ''),
-    ('a\x1bb', 'ab'),
+    ('\x1b', '\x1b'),
+    ('a\x1bb', 'a\x1bb'),
     ('\x1b[', ''),
     ('text\x1b[mmore', 'textmore'),
 ]

--- a/tests/test_width.py
+++ b/tests/test_width.py
@@ -28,6 +28,8 @@ IGNORE_MODE_CASES = [
     ('abc\nxy', 5, 'LF'),
     ('\x1b[31mred\x1b[0m', 3, 'SGR_sequence'),
     ('hello\x80world', 10, 'C1_control'),
+    ('\x1b', 0, 'lone_ESC'),
+    ('a\x1bb', 2, 'lone_ESC_between'),
 ]
 
 
@@ -62,6 +64,9 @@ STRICT_ALLOWED_CASES = [
     ('abc\rxy', 3, 'CR'),
     ('\x1b[31mred\x1b[0m', 3, 'SGR_sequence'),
     ('a\x1b[2Cb', 4, 'cursor_right'),
+    ('\x1b', 0, 'lone_ESC'),
+    ('a\x1bb', 2, 'lone_ESC_between'),
+    ('\x1b!', 1, 'ESC_unrecognized'),
 ]
 
 
@@ -139,7 +144,7 @@ ESCAPE_SEQUENCE_CASES = [
     ('\x1b]8;;https://example.com\x07link\x1b]8;;\x07', 4, 'OSC_hyperlink'),
     ('\x1b]0;title\x07text', 4, 'OSC_title'),
     ('\x1b(B', 0, 'charset'),
-    ('\x1b[', 0, 'incomplete_CSI'),
+    ('\x1b[', 0, 'Fe_CSI'),
 ]
 
 

--- a/wcwidth/wcwidth.py
+++ b/wcwidth/wcwidth.py
@@ -679,8 +679,7 @@ def strip_sequences(text):
     r"""
     Return text with all terminal escape sequences removed.
 
-    This is a simple wrapper around :func:`iter_sequences` that concatenates
-    all non-sequence segments.
+    Unknown or incomplete ESC sequences are preserved.
 
     :param str text: String that may contain terminal escape sequences.
     :rtype: str
@@ -697,7 +696,7 @@ def strip_sequences(text):
         >>> strip_sequences('\\x1b[1m\\x1b[31mbold red\\x1b[0m text')
         'bold red text'
     """
-    return ''.join(segment for segment, is_seq in iter_sequences(text) if not is_seq)
+    return ZERO_WIDTH_PATTERN.sub('', text)
 
 
 def clip(text, start, end, *, fillchar=' ', tabsize=8, ambiguous_width=1):


### PR DESCRIPTION
3-20x+ performance increase, just using re.sub instead

However, this effects unknown or incomplete sequences, and, that is
preferable, that any random/unknown "ESC" in a string is kept, but,
ignored by higher level functions like width() as a control code, and,
preserved in cut(), document as such
