### PR TITLE
docfix: accidental double-escapes \\t -> \t

### DIFF
--- a/wcwidth/escape_sequences.py
+++ b/wcwidth/escape_sequences.py
@@ -2,7 +2,7 @@ r"""
 Terminal escape sequence patterns.
 
 This module provides regex patterns for matching terminal escape sequences. All patterns match
-sequences that begin with ESC (\\x1b). Before calling re.match with these patterns, callers should
+sequences that begin with ESC (\x1b). Before calling re.match with these patterns, callers should
 first check that the character at the current position is ESC for optimal performance.
 """
 # std imports

--- a/wcwidth/escape_sequences.py
+++ b/wcwidth/escape_sequences.py
@@ -2,8 +2,8 @@ r"""
 Terminal escape sequence patterns.
 
 This module provides regex patterns for matching terminal escape sequences. All patterns match
-sequences that begin with ESC (\x1b). Before calling re.match with these patterns, callers should
-first check that the character at the current position is ESC for optimal performance.
+sequences that begin with ESC (``\x1b``). Before calling re.match with these patterns, callers
+should first check that the character at the current position is ESC for optimal performance.
 """
 # std imports
 import re

--- a/wcwidth/grapheme.py
+++ b/wcwidth/grapheme.py
@@ -257,12 +257,12 @@ def iter_graphemes(
 
     Example::
 
-        >>> list(iter_graphemes('cafe\\u0301'))
-        ['c', 'a', 'f', 'e\\u0301']
-        >>> list(iter_graphemes('\\U0001F468\\u200D\\U0001F469\\u200D\\U0001F467'))
-        ['o', 'k', '\\U0001F468\\u200D\\U0001F469\\u200D\\U0001F467']
-        >>> list(iter_graphemes('\\U0001F1FA\\U0001F1F8'))
-        ['o', 'k', '\\U0001F1FA\\U0001F1F8']
+        >>> list(iter_graphemes('cafe\u0301'))
+        ['c', 'a', 'f', 'e\u0301']
+        >>> list(iter_graphemes('\U0001F468\u200D\U0001F469\u200D\U0001F467'))
+        ['o', 'k', '\U0001F468\u200D\U0001F469\u200D\U0001F467']
+        >>> list(iter_graphemes('\U0001F1FA\U0001F1F8'))
+        ['o', 'k', '\U0001F1FA\U0001F1F8']
 
     .. versionadded:: 0.3.0
     """

--- a/wcwidth/textwrap.py
+++ b/wcwidth/textwrap.py
@@ -353,10 +353,10 @@ def wrap(text: str, width: int = 70, *,
     whitespace and collapsed. To preserve paragraph breaks, wrap each
     paragraph separately::
 
-        >>> text = 'First line.\\nSecond line.'
+        >>> text = 'First line.\nSecond line.'
         >>> wrap(text, 40)  # newline collapsed to space
         ['First line. Second line.']
-        >>> [line for para in text.split('\\n')
+        >>> [line for para in text.split('\n')
         ...  for line in (wrap(para, 40) if para else [''])]
         ['First line.', 'Second line.']
 

--- a/wcwidth/wcwidth.py
+++ b/wcwidth/wcwidth.py
@@ -398,10 +398,10 @@ def iter_sequences(text: str) -> Iterator[tuple[str, bool]]:
 
         >>> list(iter_sequences('hello'))
         [('hello', False)]
-        >>> list(iter_sequences('\\x1b[31mred'))
-        [('\\x1b[31m', True), ('red', False)]
-        >>> list(iter_sequences('\\x1b[1m\\x1b[31m'))
-        [('\\x1b[1m', True), ('\\x1b[31m', True)]
+        >>> list(iter_sequences('\x1b[31mred'))
+        [('\x1b[31m', True), ('red', False)]
+        >>> list(iter_sequences('\x1b[1m\x1b[31m'))
+        [('\x1b[1m', True), ('\x1b[31m', True)]
     """
     idx = 0
     text_len = len(text)
@@ -461,16 +461,16 @@ def width(
     :param text: String to measure.
     :param control_codes: How to handle control characters and sequences:
 
-        - ``'parse'`` (default): Track horizontal cursor movement from BS ``\\b``, CR ``\\r``, TAB
-          ``\\t``, and cursor left and right movement sequences.  Vertical movement (LF, VT, FF) and
+        - ``'parse'`` (default): Track horizontal cursor movement from BS ``\b``, CR ``\r``, TAB
+          ``\t``, and cursor left and right movement sequences.  Vertical movement (LF, VT, FF) and
           indeterminate sequences are zero-width. Never raises.
         - ``'strict'``: Like parse, but raises :exc:`ValueError` on control characters with
           indeterminate results of the screen or cursor, like clear or vertical movement. Generally,
           these should be handled with a virtual terminal emulator (like 'pyte').
         - ``'ignore'``: All C0 and C1 control characters and escape sequences are measured as
           width 0. This is the fastest measurement for text already filtered or known not to contain
-          any kinds of control codes or sequences. TAB ``\\t`` is zero-width; for tab expansion,
-          pre-process: ``text.replace('\\t', ' ' * 8)``.
+          any kinds of control codes or sequences. TAB ``\t`` is zero-width; for tab expansion,
+          pre-process: ``text.replace('\t', ' ' * 8)``.
 
     :param tabsize: Tab stop width for ``'parse'`` and ``'strict'`` modes. Default is 8.
         Must be positive. Has no effect when ``control_codes='ignore'``.
@@ -492,17 +492,17 @@ def width(
         5
         >>> width('コンニチハ')
         10
-        >>> width('\\x1b[31mred\\x1b[0m')
+        >>> width('\x1b[31mred\x1b[0m')
         3
-        >>> width('\\x1b[31mred\\x1b[0m', control_codes='ignore')  # same result (ignored)
+        >>> width('\x1b[31mred\x1b[0m', control_codes='ignore')  # same result (ignored)
         3
-        >>> width('123\\b4')     # backspace overwrites previous cell (outputs '124')
+        >>> width('123\b4')     # backspace overwrites previous cell (outputs '124')
         3
-        >>> width('abc\\t')      # tab caused cursor to move to column 8
+        >>> width('abc\t')      # tab caused cursor to move to column 8
         8
-        >>> width('1\\x1b[10C')  # '1' + cursor right 10, cursor ends on column 11
+        >>> width('1\x1b[10C')  # '1' + cursor right 10, cursor ends on column 11
         11
-        >>> width('1\\x1b[10C', control_codes='ignore')   # faster but wrong in this case
+        >>> width('1\x1b[10C', control_codes='ignore')   # faster but wrong in this case
         1
     """
     # pylint: disable=too-complex,too-many-branches,too-many-statements,too-many-locals
@@ -647,9 +647,9 @@ def ljust(
 
         >>> wcwidth.ljust('hi', 5)
         'hi   '
-        >>> wcwidth.ljust('\\x1b[31mhi\\x1b[0m', 5)
-        '\\x1b[31mhi\\x1b[0m   '
-        >>> wcwidth.ljust('\\U0001F468\\u200D\\U0001F469\\u200D\\U0001F467', 6)
+        >>> wcwidth.ljust('\x1b[31mhi\x1b[0m', 5)
+        '\x1b[31mhi\x1b[0m   '
+        >>> wcwidth.ljust('\U0001F468\u200D\U0001F469\u200D\U0001F467', 6)
         '👨‍👩‍👧    '
     """
     if text.isascii() and text.isprintable():
@@ -688,9 +688,9 @@ def rjust(
 
         >>> wcwidth.rjust('hi', 5)
         '   hi'
-        >>> wcwidth.rjust('\\x1b[31mhi\\x1b[0m', 5)
-        '   \\x1b[31mhi\\x1b[0m'
-        >>> wcwidth.rjust('\\U0001F468\\u200D\\U0001F469\\u200D\\U0001F467', 6)
+        >>> wcwidth.rjust('\x1b[31mhi\x1b[0m', 5)
+        '   \x1b[31mhi\x1b[0m'
+        >>> wcwidth.rjust('\U0001F468\u200D\U0001F469\u200D\U0001F467', 6)
         '    👨‍👩‍👧'
     """
     if text.isascii() and text.isprintable():
@@ -732,9 +732,9 @@ def center(
 
         >>> wcwidth.center('hi', 6)
         '  hi  '
-        >>> wcwidth.center('\\x1b[31mhi\\x1b[0m', 6)
-        '  \\x1b[31mhi\\x1b[0m  '
-        >>> wcwidth.center('\\U0001F468\\u200D\\U0001F469\\u200D\\U0001F467', 6)
+        >>> wcwidth.center('\x1b[31mhi\x1b[0m', 6)
+        '  \x1b[31mhi\x1b[0m  '
+        >>> wcwidth.center('\U0001F468\u200D\U0001F469\u200D\U0001F467', 6)
         '  👨‍👩‍👧  '
     """
     if text.isascii() and text.isprintable():
@@ -760,11 +760,11 @@ def strip_sequences(text: str) -> str:
 
     Example::
 
-        >>> strip_sequences('\\x1b[31mred\\x1b[0m')
+        >>> strip_sequences('\x1b[31mred\x1b[0m')
         'red'
         >>> strip_sequences('hello')
         'hello'
-        >>> strip_sequences('\\x1b[1m\\x1b[31mbold red\\x1b[0m text')
+        >>> strip_sequences('\x1b[1m\x1b[31mbold red\x1b[0m text')
         'bold red text'
     """
     return ZERO_WIDTH_PATTERN.sub('', text)
@@ -787,7 +787,7 @@ def clip(
     they have zero display width. If a wide character (width 2) would be split at
     either boundary, it is replaced with ``fillchar``.
 
-    TAB characters (``\\t``) are expanded to spaces up to the next tab stop,
+    TAB characters (``\t``) are expanded to spaces up to the next tab stop,
     controlled by the ``tabsize`` parameter.
 
     Other cursor movement characters (backspace, carriage return) and cursor
@@ -814,7 +814,7 @@ def clip(
         'hello'
         >>> clip('中文字', 0, 3)  # Wide char split at column 3
         '中 '
-        >>> clip('a\\tb', 0, 10)  # Tab expanded to spaces
+        >>> clip('a\tb', 0, 10)  # Tab expanded to spaces
         'a       b'
     """
     # pylint: disable=too-complex,too-many-locals,too-many-branches


### PR DESCRIPTION
I'm not sure how these all got changed, maybe by some dance of adding or
removing r before "" and docformatter/pylint/autopep8 combination!
