### PR TITLE
Bugfix Virama, matching uucode (ghostty)

### DIFF
--- a/bin/update-tables.py
+++ b/bin/update-tables.py
@@ -798,6 +798,9 @@ def parse_indic_conjunct_breaks(fname: str) -> dict[str, TableDef]:
     }
 
 
+# ISC_CONSONANT is generated for the public API but not used by the runtime.
+# Virama and Invisible_Stacker are treated as zero-width combining marks (Mn),
+# matching Ghostty's uucode; the runtime no longer consults the ISC categories.
 ISC_VALUES = ('Consonant', 'Virama', 'Invisible_Stacker')
 
 

--- a/bin/update-tables.py
+++ b/bin/update-tables.py
@@ -798,7 +798,7 @@ def parse_indic_conjunct_breaks(fname: str) -> dict[str, TableDef]:
     }
 
 
-ISC_VALUES = ('Consonant',)
+ISC_VALUES = ('Consonant', 'Virama', 'Invisible_Stacker')
 
 
 def parse_indic_syllabic_category(fname: str) -> dict[str, TableDef]:

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -539,9 +539,10 @@ History
 =======
 
 0.8.0 *(unreleased)*
-  * **Improved** memory resource usage and import time for Python 3.15 using lazy imports `PR #221`_.
+  * **Improved** memory usage and import time for Python 3.15 using lazy imports `PR #221`_.
   * **Improved** performance on Python 3.15 using standard library iter_graphemes() `PR #206`_.
-  * **Bugfix** Invisible_Stacker virama conjunct formation for Burmese, Khmer, and 12 other scripts.
+  * **Bugfix** Invisible_Stacker viramas now form conjuncts (Burmese, Khmer, etc.) and
+    change some Virama width calculations to match `jacobsandlund/uucode`_ (ghostty) `PR #XXX`_.
 
 0.7.0 *2026-05-02*
   * **New** support for `kitty text sizing protocol`_ (OSC 66) in `width()`_ and `clip()`_.

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -506,10 +506,15 @@ This library is used in:
 Other Languages
 ===============
 
-There are similar implementations of the `wcwidth()`_ and `wcswidth()`_ functions in other
-languages.
+The following libraries provide grapheme and emoji support and closely align with our
+specification_:
 
-- `contour-terminal/libunicode`_: C++20
+- `jacobsandlund/uucode`_ Zig
+- `contour-terminal/libunicode`_ C++20
+
+There are similar implementations of at least the `wcwidth()`_ and `wcswidth()`_ functions in other
+languages:
+
 - `ridiculousfish/widecharwidth`_: Python
 - `termux/wcwidth`_: C
 - `powerman/wcwidth-icons`_: C
@@ -536,6 +541,7 @@ History
 0.8.0 *(unreleased)*
   * **Improved** memory resource usage and import time for Python 3.15 using lazy imports `PR #221`_.
   * **Improved** performance on Python 3.15 using standard library iter_graphemes() `PR #206`_.
+  * **Bugfix** Invisible_Stacker virama conjunct formation for Burmese, Khmer, and 12 other scripts.
 
 0.7.0 *2026-05-02*
   * **New** support for `kitty text sizing protocol`_ (OSC 66) in `width()`_ and `clip()`_.
@@ -799,6 +805,7 @@ https://www.cl.cam.ac.uk/~mgk25/ucs/wcwidth.c::
 .. _`joshuarubin/wcwidth9`: https://github.com/joshuarubin/wcwidth9
 .. _`spectreconsole/wcwidth`: https://github.com/spectreconsole/wcwidth
 .. _`contour-terminal/libunicode`: https://github.com/contour-terminal/libunicode
+.. _`jacobsandlund/uucode`: https://github.com/jacobsandlund/uucode
 .. _`ridiculousfish/widecharwidth`: https://github.com/ridiculousfish/widecharwidth
 .. _`termux/wcwidth`: https://github.com/termux/wcwidth
 .. _`powerman/wcwidth-icons`: https://github.com/powerman/wcwidth-icons

--- a/docs/specs.rst
+++ b/docs/specs.rst
@@ -114,9 +114,12 @@ by a Nukta (``Mn``) and then a vowel sign (``Mc``) is measured as base + 1.
 Virama Conjunct Formation
 -------------------------
 
-In `Brahmic scripts`_, a `Virama`_ (``Indic_Syllabic_Category=Virama`` in
-`IndicSyllabicCategory.txt`_) between two consonants triggers `conjunct`_
-formation: the consonants are merged into a single ligature glyph.
+In `Brahmic scripts`_, `IndicSyllabicCategory.txt`_ defines two categories
+that trigger `conjunct`_ formation between consonants: `Virama`_ ("may act
+as a Pure_Killer or Invisible_Stacker depending on context") and
+``Invisible_Stacker``_ ("not visible by itself; causes conjunct formation
+or consonant stacking", the "only as consonant stackers" category
+described in the Virama section header).
 
 - A ``Consonant`` immediately following a ``Virama`` contributes 0 width.
 - The conjunct still occupies cells and the next visible advance settles it:
@@ -176,6 +179,7 @@ See also: `L2/2023/23107`_ "Proper Complex Script Support in Text Terminals".
 .. _`Nonspacing Mark`: https://www.unicode.org/versions/latest/core-spec/chapter-4/#G134153
 .. _`IndicSyllabicCategory.txt`: https://www.unicode.org/Public/UCD/latest/ucd/IndicSyllabicCategory.txt
 .. _`Indic_Syllabic_Category`: https://www.unicode.org/reports/tr44/#Indic_Syllabic_Category
+.. _`Invisible_Stacker`: https://www.unicode.org/Public/UCD/latest/ucd/IndicSyllabicCategory.txt
 .. _`Brahmic scripts`: https://en.wikipedia.org/wiki/Brahmic_scripts
 .. _`Virama`: https://www.unicode.org/glossary/#virama
 .. _`conjunct`: https://www.unicode.org/glossary/#consonant_conjunct

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -454,6 +454,18 @@ def test_virama_conjunct(phrase, expected):
     assert wcwidth.width(phrase) == expected
 
 
+@pytest.mark.parametrize("phrase,expected", [
+    ("\u1000\u1039\u1000", 2),             # Burmese KA+VIRAMA+KA
+    ("\u1000\u1039\u1000\u1039\u1002", 2),  # Burmese KA+V+KA+V+GA
+    ("\u1000\u1039\u200D\u1000", 2),       # Burmese KA+V+ZWJ+KA
+    ("\u1782\u17D2\u1782\u17C1", 2),       # Khmer KO+COENG+KO+VOWEL_E (Mc closes)
+    ("\u1780\u17D2\u1780", 2),             # Khmer KA+COENG+KA
+])
+def test_virama_conjunct_invisible_stacker(phrase, expected):
+    assert wcwidth.wcswidth(phrase) == expected
+    assert wcwidth.width(phrase) == expected
+
+
 def test_zwj_at_end_of_string():
     """ZWJ at end of string (not after virama) is consumed with zero width."""
     assert wcwidth.wcswidth('a\u200D') == 1

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -309,7 +309,7 @@ def test_devanagari_script():
     # 23107-terminal-suppt.pdf suggests wcwidth.wcwidth should return (2, 0, 0, 1)
     expect_length_each = (1, 0, 1, 0)
     # virama conjunct collapses KA+virama+SSA into one cell, Mc adds +1
-    expect_length_phrase = 2
+    expect_length_phrase = 3
 
     # exercise,
     length_each = tuple(map(wcwidth.wcwidth, phrase))
@@ -331,7 +331,7 @@ def test_tamil_script():
     expect_length_each = (1, 0, 1, 0)
 
     # virama conjunct collapses KA+virama+SSA into one cell, Mc adds +1
-    expect_length_phrase = 2
+    expect_length_phrase = 3
 
     # exercise,
     length_each = tuple(map(wcwidth.wcwidth, phrase))
@@ -354,7 +354,7 @@ def test_kannada_script():
     # 23107-terminal-suppt.pdf suggests should be (2, 0, 3, 1)
     expect_length_each = (1, 0, 1, 0)
     # virama conjunct collapses RA+virama+JHA into one cell, Mc adds +1
-    expect_length_phrase = 2
+    expect_length_phrase = 3
 
     # exercise,
     length_each = tuple(map(wcwidth.wcwidth, phrase))
@@ -437,16 +437,16 @@ def test_mc_width_consistency(repeat):
 
 
 @pytest.mark.parametrize("phrase,expected", [
-    ("\u0999\u09CD\u0997\u09C7", 2),
-    ("\u0915\u094D\u0924\u093F", 2),
-    ("\u0915\u094D\u0930\u093F", 2),
-    ("\u0A95\u0ACD\u0A95\u0ACB", 2),
-    ("\u0938\u094D\u0924\u094D\u0930", 2),
+    ("\u0999\u09CD\u0997\u09C7", 3),
+    ("\u0915\u094D\u0924\u093F", 3),
+    ("\u0915\u094D\u0930\u093F", 3),
+    ("\u0A95\u0ACD\u0A95\u0ACB", 3),
+    ("\u0938\u094D\u0924\u094D\u0930", 3),
     ("\u0938\u094D\u0924", 2),
     ("\u0915\u094D\u0020", 2),
     ("\u09A4\u09CD\u200D\u09AA", 2),
     ("\u0915\u094D\u200D\u0924", 2),
-    ("\u0D15\u0D4D\u0D15\u0D41\u0D02", 2),
+    ("\u0D15\u0D4D\u0D15\u0D41\u0D02", 3),
     ("\u0915\u094D\u0924\u0941\u0902", 2),
 ])
 def test_virama_conjunct(phrase, expected):
@@ -456,9 +456,9 @@ def test_virama_conjunct(phrase, expected):
 
 @pytest.mark.parametrize("phrase,expected", [
     ("\u1000\u1039\u1000", 2),             # Burmese KA+VIRAMA+KA
-    ("\u1000\u1039\u1000\u1039\u1002", 2),  # Burmese KA+V+KA+V+GA
+    ("\u1000\u1039\u1000\u1039\u1002", 3),  # Burmese KA+V+KA+V+GA
     ("\u1000\u1039\u200D\u1000", 2),       # Burmese KA+V+ZWJ+KA
-    ("\u1782\u17D2\u1782\u17C1", 2),       # Khmer KO+COENG+KO+VOWEL_E (Mc closes)
+    ("\u1782\u17D2\u1782\u17C1", 3),       # Khmer KO+COENG+KO+VOWEL_E (Mc closes)
     ("\u1780\u17D2\u1780", 2),             # Khmer KA+COENG+KA
 ])
 def test_virama_conjunct_invisible_stacker(phrase, expected):

--- a/wcwidth/_constants.py
+++ b/wcwidth/_constants.py
@@ -4,7 +4,10 @@
 from .table_mc import CATEGORY_MC
 from .table_wide import WIDE_EASTASIAN
 from .table_zero import ZERO_WIDTH
-from .table_grapheme import EXTENDED_PICTOGRAPHIC, GRAPHEME_REGIONAL_INDICATOR
+from .table_grapheme import (ISC_VIRAMA,
+                             EXTENDED_PICTOGRAPHIC,
+                             ISC_INVISIBLE_STACKER,
+                             GRAPHEME_REGIONAL_INDICATOR)
 from .table_ambiguous import AMBIGUOUS_EASTASIAN
 from .unicode_versions import list_versions
 
@@ -23,35 +26,10 @@ __all__ = (
 _REGIONAL_INDICATOR_SET = frozenset(
     range(GRAPHEME_REGIONAL_INDICATOR[0][0], GRAPHEME_REGIONAL_INDICATOR[0][1] + 1)
 )
-_ISC_VIRAMA_SET = frozenset((
-    0x094D,   # DEVANAGARI SIGN VIRAMA
-    0x09CD,   # BENGALI SIGN VIRAMA
-    0x0A4D,   # GURMUKHI SIGN VIRAMA
-    0x0ACD,   # GUJARATI SIGN VIRAMA
-    0x0B4D,   # ORIYA SIGN VIRAMA
-    0x0BCD,   # TAMIL SIGN VIRAMA
-    0x0C4D,   # TELUGU SIGN VIRAMA
-    0x0CCD,   # KANNADA SIGN VIRAMA
-    0x0D4D,   # MALAYALAM SIGN VIRAMA
-    0x0DCA,   # SINHALA SIGN AL-LAKUNA
-    0x1B44,   # BALINESE ADEG ADEG
-    0xA806,   # SYLOTI NAGRI SIGN HASANTA
-    0xA8C4,   # SAURASHTRA SIGN VIRAMA
-    0xA9C0,   # JAVANESE PANGKON
-    0x11046,  # BRAHMI VIRAMA
-    0x110B9,  # KAITHI SIGN VIRAMA
-    0x111C0,  # SHARADA SIGN VIRAMA
-    0x11235,  # KHOJKI SIGN VIRAMA
-    0x1134D,  # GRANTHA SIGN VIRAMA
-    0x11442,  # NEWA SIGN VIRAMA
-    0x114C2,  # TIRHUTA SIGN VIRAMA
-    0x115BF,  # SIDDHAM SIGN VIRAMA
-    0x1163F,  # MODI SIGN VIRAMA
-    0x116B6,  # TAKRI SIGN VIRAMA
-    0x11839,  # DOGRA SIGN VIRAMA
-    0x119E0,  # NANDINAGARI SIGN VIRAMA
-    0x11C3F,  # BHAIKSUKI SIGN VIRAMA
-))
+_ISC_VIRAMA_SET = frozenset(
+    cp for lo, hi in (*ISC_VIRAMA, *ISC_INVISIBLE_STACKER)
+    for cp in range(lo, hi + 1)
+)
 # pylint: disable=invalid-name
 _LATEST_VERSION = list_versions()[-1]
 _CATEGORY_MC_TABLE = CATEGORY_MC[_LATEST_VERSION]

--- a/wcwidth/_wcswidth.py
+++ b/wcwidth/_wcswidth.py
@@ -8,7 +8,6 @@ __lazy_modules__ = [
     "wcwidth._constants",
     "wcwidth._wcwidth",
     "wcwidth.bisearch",
-    "wcwidth.table_grapheme",
     "wcwidth.table_vs16",
 ]
 # local
@@ -20,7 +19,6 @@ from ._constants import (_EMOJI_ZWJ_SET,
                          _FITZPATRICK_RANGE,
                          _REGIONAL_INDICATOR_SET)
 from .table_vs16 import VS16_NARROW_TO_WIDE
-from .table_grapheme import ISC_CONSONANT
 
 
 def wcswidth(
@@ -74,26 +72,29 @@ def wcswidth(
     # grapheme-clustering state
     last_measured_idx = -2
     last_measured_ucs = -1
-    last_was_virama = False
-    conjunct_pending = False
 
     while idx < end:
         char = pwcs[idx]
         ucs = ord(char)
-
-        # ZWJ (U+200D)
+        #
+        # Much of the logic below matches the logic in width(), but is repeated for improved
+        # performance, they are given matching index reference numbers (starting at #6).
+        #
+        # 5. ZWJ (U+200D): consumed without contributing width.
         if ucs == 0x200D:
-            if last_was_virama:
+            if idx > 0 and ord(pwcs[idx - 1]) in _ISC_VIRAMA_SET:
+                # Virama codepoints (Indic_Syllabic_Category=Virama|Invisible_Stacker)
+                # are treated as zero-width combining marks, matching Ghostty's uucode
+                # library.  Whether a virama+consonant sequence should collapse to 1 or
+                # 2 cells is undefined by Unicode; we follow uucode's (1).
                 idx += 1
             elif idx + 1 < end:
-                last_was_virama = False
                 idx += 2
             else:
-                last_was_virama = False
                 idx += 1
             continue
 
-        # VS16 (U+FE0F): converts preceding narrow character to wide.
+        # 6. VS16 (U+FE0F): converts preceding narrow character to wide.
         if ucs == 0xFE0F and last_measured_idx >= 0:
             total_width += bisearch(
                 ord(pwcs[last_measured_idx]),
@@ -103,7 +104,7 @@ def wcswidth(
             idx += 1
             continue
 
-        # Regional Indicator & Fitzpatrick (both above BMP)
+        # 7. Regional Indicator & Fitzpatrick (both above BMP)
         if ucs > 0xFFFF:
             if ucs in _REGIONAL_INDICATOR_SET:
                 ri_before = 0
@@ -120,38 +121,19 @@ def wcswidth(
                 idx += 1
                 continue
 
-        # Virama conjunct formation
-        if last_was_virama and bisearch(ucs, ISC_CONSONANT):
-            last_measured_idx = idx
-            last_measured_ucs = ucs
-            last_was_virama = False
-            conjunct_pending = True
-            idx += 1
-            continue
-
-        # Normal character: measure with wcwidth
+        # 8. Normal character: measure with wcwidth
         w = _wcwidth(char)
         if w < 0:
             # C0/C1 control character
             return -1
         if w > 0:
-            if conjunct_pending:
-                total_width += 1
-                conjunct_pending = False
             total_width += w
             last_measured_idx = idx
             last_measured_ucs = ucs
-            last_was_virama = False
         elif last_measured_idx >= 0 and bisearch(ucs, _CATEGORY_MC_TABLE):
             # Spacing Combining Mark (Mc) following a base character adds 1
             total_width += 1
             last_measured_idx = -2
-            last_was_virama = False
-            conjunct_pending = False
-        else:
-            last_was_virama = ucs in _ISC_VIRAMA_SET
         idx += 1
 
-    if conjunct_pending:
-        total_width += 1
     return total_width

--- a/wcwidth/_wcswidth.py
+++ b/wcwidth/_wcswidth.py
@@ -72,6 +72,7 @@ def wcswidth(
     # grapheme-clustering state
     last_measured_idx = -2
     last_measured_ucs = -1
+    prev_was_virama = False
 
     while idx < end:
         char = pwcs[idx]
@@ -81,12 +82,11 @@ def wcswidth(
         # performance, they are given matching index reference numbers (starting at #6).
         #
         # 5. ZWJ (U+200D): consumed without contributing width.
+        # Virama codepoints are treated as zero-width combining marks (Mn), matching
+        # Ghostty's uucode library.  Whether a virama+consonant sequence should
+        # collapse to 1 or 2 cells is undefined by Unicode; we follow uucode's (1).
         if ucs == 0x200D:
-            if idx > 0 and ord(pwcs[idx - 1]) in _ISC_VIRAMA_SET:
-                # Virama codepoints (Indic_Syllabic_Category=Virama|Invisible_Stacker)
-                # are treated as zero-width combining marks, matching Ghostty's uucode
-                # library.  Whether a virama+consonant sequence should collapse to 1 or
-                # 2 cells is undefined by Unicode; we follow uucode's (1).
+            if prev_was_virama:
                 idx += 1
             elif idx + 1 < end:
                 idx += 2
@@ -130,10 +130,14 @@ def wcswidth(
             total_width += w
             last_measured_idx = idx
             last_measured_ucs = ucs
+            prev_was_virama = False
         elif last_measured_idx >= 0 and bisearch(ucs, _CATEGORY_MC_TABLE):
             # Spacing Combining Mark (Mc) following a base character adds 1
             total_width += 1
             last_measured_idx = -2
+            prev_was_virama = False
+        else:
+            prev_was_virama = ucs in _ISC_VIRAMA_SET
         idx += 1
 
     return total_width

--- a/wcwidth/_width.py
+++ b/wcwidth/_width.py
@@ -9,7 +9,6 @@ __lazy_modules__ = [
     "wcwidth.bisearch",
     "wcwidth.control_codes",
     "wcwidth.escape_sequences",
-    "wcwidth.table_grapheme",
     "wcwidth.table_vs16",
     "wcwidth.text_sizing",
 ]
@@ -25,7 +24,6 @@ from ._constants import (_EMOJI_ZWJ_SET,
 from .table_vs16 import VS16_NARROW_TO_WIDE
 from .text_sizing import TextSizing, TextSizingParams
 from .control_codes import ILLEGAL_CTRL, VERTICAL_CTRL, HORIZONTAL_CTRL, ZERO_WIDTH_CTRL
-from .table_grapheme import ISC_CONSONANT
 from .escape_sequences import (_SEQUENCE_CLASSIFY,
                                TEXT_SIZING_PATTERN,
                                CURSOR_MOVEMENT_SEQUENCE,
@@ -171,8 +169,6 @@ def width(
     # grapheme-clustering state
     last_measured_idx = -2
     last_measured_ucs = -1
-    last_was_virama = False
-    conjunct_pending = False
 
     while idx < text_len:
         char = text[idx]
@@ -271,23 +267,25 @@ def width(
             last_measured_ucs = -1
             continue
 
-        # 5. Inline grapheme-clustering: ZWJ, VS16, Regional Indicators,
-        #    Fitzpatrick, Virama conjuncts, Mc, wcwidth
         ucs = ord(char)
 
-        # ZWJ (U+200D)
+        # 5. Inline grapheme-clustering: ZWJ, VS16, Regional Indicators,
+        #    Fitzpatrick, Virama conjuncts, Mc, wcwidth
         if ucs == 0x200D:
-            if last_was_virama:
+            # ZWJ (U+200D): consumed without contributing width.
+            if idx > 0 and ord(text[idx - 1]) in _ISC_VIRAMA_SET:
+                # Virama codepoints (Indic_Syllabic_Category=Virama|Invisible_Stacker)
+                # are treated as zero-width combining marks, matching Ghostty's uucode
+                # library.  Whether a virama+consonant sequence should collapse to 1 or
+                # 2 cells is undefined by Unicode; we follow uucode's (1).
                 idx += 1
             elif idx + 1 < text_len:
-                last_was_virama = False
                 idx += 2
             else:
-                last_was_virama = False
                 idx += 1
             continue
 
-        # VS16 (U+FE0F): converts preceding narrow character to wide.
+        # 6. VS16 (U+FE0F): converts preceding narrow character to wide.
         if ucs == 0xFE0F and last_measured_idx >= 0:
             if bisearch(ord(text[last_measured_idx]), VS16_NARROW_TO_WIDE['9.0.0']):
                 current_col += 1
@@ -296,7 +294,7 @@ def width(
             idx += 1
             continue
 
-        # Regional Indicator & Fitzpatrick (both above BMP)
+        # 7. Regional Indicator & Fitzpatrick (both above BMP)
         if ucs > 0xFFFF:
             if ucs in _REGIONAL_INDICATOR_SET:
                 ri_before = 0
@@ -313,38 +311,18 @@ def width(
                 idx += 1
                 continue
 
-        # Virama conjunct formation
-        if last_was_virama and bisearch(ucs, ISC_CONSONANT):
-            last_measured_idx = idx
-            last_measured_ucs = ucs
-            last_was_virama = False
-            conjunct_pending = True
-            idx += 1
-            continue
-
-        # Normal character: measure with wcwidth
+        # 8. Normal character: measure with wcwidth
         w = _wcwidth(char)
         if w > 0:
-            if conjunct_pending:
-                current_col += 1
-                conjunct_pending = False
             current_col += w
             max_extent = max(max_extent, current_col)
             last_measured_idx = idx
             last_measured_ucs = ucs
-            last_was_virama = False
         elif last_measured_idx >= 0 and bisearch(ucs, _CATEGORY_MC_TABLE):
             # Spacing Combining Mark (Mc) following a base character adds 1
             current_col += 1
             max_extent = max(max_extent, current_col)
             last_measured_idx = -2
-            last_was_virama = False
-            conjunct_pending = False
-        else:
-            last_was_virama = ucs in _ISC_VIRAMA_SET
         idx += 1
 
-    if conjunct_pending:
-        current_col += 1
-        max_extent = max(max_extent, current_col)
     return max_extent

--- a/wcwidth/_width.py
+++ b/wcwidth/_width.py
@@ -169,6 +169,7 @@ def width(
     # grapheme-clustering state
     last_measured_idx = -2
     last_measured_ucs = -1
+    prev_was_virama = False
 
     while idx < text_len:
         char = text[idx]
@@ -271,13 +272,11 @@ def width(
 
         # 5. Inline grapheme-clustering: ZWJ, VS16, Regional Indicators,
         #    Fitzpatrick, Virama conjuncts, Mc, wcwidth
+        # Virama codepoints are treated as zero-width combining marks (Mn), matching
+        # Ghostty's uucode library.  Whether a virama+consonant sequence should
+        # collapse to 1 or 2 cells is undefined by Unicode; we follow uucode's (1).
         if ucs == 0x200D:
-            # ZWJ (U+200D): consumed without contributing width.
-            if idx > 0 and ord(text[idx - 1]) in _ISC_VIRAMA_SET:
-                # Virama codepoints (Indic_Syllabic_Category=Virama|Invisible_Stacker)
-                # are treated as zero-width combining marks, matching Ghostty's uucode
-                # library.  Whether a virama+consonant sequence should collapse to 1 or
-                # 2 cells is undefined by Unicode; we follow uucode's (1).
+            if prev_was_virama:
                 idx += 1
             elif idx + 1 < text_len:
                 idx += 2
@@ -318,11 +317,15 @@ def width(
             max_extent = max(max_extent, current_col)
             last_measured_idx = idx
             last_measured_ucs = ucs
+            prev_was_virama = False
         elif last_measured_idx >= 0 and bisearch(ucs, _CATEGORY_MC_TABLE):
             # Spacing Combining Mark (Mc) following a base character adds 1
             current_col += 1
             max_extent = max(max_extent, current_col)
             last_measured_idx = -2
+            prev_was_virama = False
+        else:
+            prev_was_virama = ucs in _ISC_VIRAMA_SET
         idx += 1
 
     return max_extent

--- a/wcwidth/table_grapheme.py
+++ b/wcwidth/table_grapheme.py
@@ -2292,3 +2292,56 @@ ISC_CONSONANT = (
     (0x16101, 0x1611d,),  # Gurung Khema Letter Ka  ..Gurung Khema Letter Sa
     (0x16d43, 0x16d62,),  # Kirat Rai Letter A      ..Kirat Rai Letter Ha
 )
+
+ISC_VIRAMA = (
+    # Source: IndicSyllabicCategory
+    # Date: see file
+    #
+    (0x0094d, 0x0094d,),  # Devanagari Sign Virama
+    (0x009cd, 0x009cd,),  # Bengali Sign Virama
+    (0x00a4d, 0x00a4d,),  # Gurmukhi Sign Virama
+    (0x00acd, 0x00acd,),  # Gujarati Sign Virama
+    (0x00b4d, 0x00b4d,),  # Oriya Sign Virama
+    (0x00bcd, 0x00bcd,),  # Tamil Sign Virama
+    (0x00c4d, 0x00c4d,),  # Telugu Sign Virama
+    (0x00ccd, 0x00ccd,),  # Kannada Sign Virama
+    (0x00d4d, 0x00d4d,),  # Malayalam Sign Virama
+    (0x00dca, 0x00dca,),  # Sinhala Sign Al-lakuna
+    (0x01b44, 0x01b44,),  # Balinese Adeg Adeg
+    (0x0a806, 0x0a806,),  # Syloti Nagri Sign Hasanta
+    (0x0a8c4, 0x0a8c4,),  # Saurashtra Sign Virama
+    (0x0a9c0, 0x0a9c0,),  # Javanese Pangkon
+    (0x11046, 0x11046,),  # Brahmi Virama
+    (0x110b9, 0x110b9,),  # Kaithi Sign Virama
+    (0x111c0, 0x111c0,),  # Sharada Sign Virama
+    (0x11235, 0x11235,),  # Khojki Sign Virama
+    (0x1134d, 0x1134d,),  # Grantha Sign Virama
+    (0x11442, 0x11442,),  # Newa Sign Virama
+    (0x114c2, 0x114c2,),  # Tirhuta Sign Virama
+    (0x115bf, 0x115bf,),  # Siddham Sign Virama
+    (0x1163f, 0x1163f,),  # Modi Sign Virama
+    (0x116b6, 0x116b6,),  # Takri Sign Virama
+    (0x11839, 0x11839,),  # Dogra Sign Virama
+    (0x119e0, 0x119e0,),  # Nandinagari Sign Virama
+    (0x11c3f, 0x11c3f,),  # Bhaiksuki Sign Virama
+)
+
+ISC_INVISIBLE_STACKER = (
+    # Source: IndicSyllabicCategory
+    # Date: see file
+    #
+    (0x01039, 0x01039,),  # Myanmar Sign Virama
+    (0x017d2, 0x017d2,),  # Khmer Sign Coeng
+    (0x01a60, 0x01a60,),  # Tai Tham Sign Sakot
+    (0x01bab, 0x01bab,),  # Sundanese Sign Virama
+    (0x0aaf6, 0x0aaf6,),  # Meetei Mayek Virama
+    (0x10a3f, 0x10a3f,),  # Kharoshthi Virama
+    (0x11133, 0x11133,),  # Chakma Virama
+    (0x113d0, 0x113d0,),  # Tulu-tigalari Conjoiner
+    (0x1193e, 0x1193e,),  # Dives Akuru Virama
+    (0x11a47, 0x11a47,),  # Zanabazar Square Subjoiner
+    (0x11a99, 0x11a99,),  # Soyombo Subjoiner
+    (0x11d45, 0x11d45,),  # Masaram Gondi Virama
+    (0x11d97, 0x11d97,),  # Gunjala Gondi Virama
+    (0x11f42, 0x11f42,),  # Kawi Conjoiner
+)

--- a/wcwidth/wcwidth.py
+++ b/wcwidth/wcwidth.py
@@ -67,7 +67,6 @@ from .escape_sequences import (ZERO_WIDTH_PATTERN,
                                strip_sequences)
 from .unicode_versions import list_versions
 
-
 __all__ = (
     'ZERO_WIDTH',
     'WIDE_EASTASIAN',

--- a/wcwidth/wcwidth.py
+++ b/wcwidth/wcwidth.py
@@ -58,7 +58,6 @@ from .table_vs16 import VS16_NARROW_TO_WIDE
 from .table_wide import WIDE_EASTASIAN
 from .table_zero import ZERO_WIDTH
 from .control_codes import ILLEGAL_CTRL, VERTICAL_CTRL, HORIZONTAL_CTRL, ZERO_WIDTH_CTRL
-from .table_grapheme import ISC_CONSONANT, EXTENDED_PICTOGRAPHIC, GRAPHEME_REGIONAL_INDICATOR
 from .table_ambiguous import AMBIGUOUS_EASTASIAN
 from .escape_sequences import (ZERO_WIDTH_PATTERN,
                                CURSOR_LEFT_SEQUENCE,
@@ -68,7 +67,6 @@ from .escape_sequences import (ZERO_WIDTH_PATTERN,
                                strip_sequences)
 from .unicode_versions import list_versions
 
-_ISC_CONSONANT_TABLE = ISC_CONSONANT
 
 __all__ = (
     'ZERO_WIDTH',


### PR DESCRIPTION
After careful review of Virama width calculation and study of uucode, two related changes:

- Bugfix Invisible_Stacker viramas now form conjuncts (Burmese, Khmer, etc.)

   Discovered while analyzing Burmese, found in ``IndicSyllabicCategory.txt``, "causes conjunct
   formation", added in Unicode 14.0:

       # Indic_Syllabic_Category=Invisible_Stacker
       #
       # Invisible stacker (usually kills inherent vowel of consonant; is not visible
       #                    by itself; causes conjunct formation or consonant
       #                    stacking)

   So this logically belongs with the others in ``_ISC_VIRAMA_SET``. Use code generation instead of
   the copy and paste done before, this set would have changed in several past unicode releases and
   so may change again in the future.

- Change Virama+consonant width calculation to match @jacobsandlund's uucode (ghostty)

  Our previous implementation was perhaps too complex, but more "giving" for width compared to
  uucode's implementation, and neither of ours really has any basis in standards, seems to be of
  taste.  contour's libunicode does not make concern for virama, and uucode's does, measurement
  is simpler to implement and will probably improve performance, see code comment::

        # Virama codepoints (Indic_Syllabic_Category=Virama|Invisible_Stacker)
        # are treated as zero-width combining marks, matching Ghostty's uucode
        # library.  Whether a virama+consonant sequence should collapse to 1 or
        # 2 cells is undefined by Unicode; we follow uucode's (1).
