### PR TITLE
Cap grapheme final width at 2 (foot, ghostty, terminal.exe)

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -26,6 +26,8 @@ disable=
     too-many-boolean-expressions,
     redundant-u-string-prefix,
     consider-using-f-string,
+    consider-using-max-builtin,
+    consider-using-min-builtin,
 
 [FORMAT]
 max-line-length: 100

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -539,10 +539,12 @@ History
 =======
 
 0.8.0 *(unreleased)*
-  * **Improved** memory usage and import time for Python 3.15 using lazy imports `PR #221`_.
   * **Improved** performance on Python 3.15 using standard library iter_graphemes() `PR #206`_.
+  * **Improved** memory usage and import time for Python 3.15 using lazy imports `PR #221`_.
   * **Bugfix** Invisible_Stacker viramas now form conjuncts (Burmese, Khmer, etc.) and
-    change some Virama width calculations to match `jacobsandlund/uucode`_ (ghostty) `PR #XXX`_.
+    change some Virama width calculations to match `jacobsandlund/uucode`_ (ghostty) `PR #223`_.
+  * **Updated** graphemes width maximum now 2, matching Ghostty, foot, and Windows Terminal `PR
+    #224`_.
 
 0.7.0 *2026-05-02*
   * **New** support for `kitty text sizing protocol`_ (OSC 66) in `width()`_ and `clip()`_.
@@ -776,6 +778,8 @@ https://www.cl.cam.ac.uk/~mgk25/ucs/wcwidth.c::
 .. _`PR #204`: https://github.com/jquast/wcwidth/pull/204
 .. _`PR #206`: https://github.com/jquast/wcwidth/pull/206
 .. _`PR #221`: https://github.com/jquast/wcwidth/pull/221
+.. _`PR #223`: https://github.com/jquast/wcwidth/pull/223
+.. _`PR #224`: https://github.com/jquast/wcwidth/pull/224
 .. _`Issue #101`: https://github.com/jquast/wcwidth/issues/101
 .. _`Issue #155`: https://github.com/jquast/wcwidth/issues/155
 .. _`Issue #190`: https://github.com/jquast/wcwidth/issues/190

--- a/docs/specs.rst
+++ b/docs/specs.rst
@@ -105,11 +105,14 @@ it directly follows, making the pair width 2. Wide characters are unchanged.
 
 Any character of non-zero width followed by an ``Mc`` (`Spacing Combining Mark`_)
 character when measured in sequence by :func:`wcwidth.wcswidth` or
-:func:`wcwidth.width`. The ``Mc`` character adds +1 to the total width,
+:func:`wcwidth.width`. The ``Mc`` character adds +1 to the cluster width,
 reflecting its *positive advance width* as defined in `General Category`_
 (Table 4-4). Zero-width combining marks (``Mn``) between the base character
 and the ``Mc`` do not break the association. For example, a consonant followed
 by a Nukta (``Mn``) and then a vowel sign (``Mc``) is measured as base + 1.
+
+All grapheme cluster widths are capped at 2 cells beginning release 0.8.0, matching
+behavior of the current grapheme-supporting terminals.
 
 Virama Conjunct Formation
 -------------------------
@@ -121,16 +124,10 @@ as a Pure_Killer or Invisible_Stacker depending on context") and
 or consonant stacking", the "only as consonant stackers" category
 described in the Virama section header).
 
-- A ``Consonant`` immediately following a ``Virama`` contributes 0 width.
-- The conjunct still occupies cells and the next visible advance settles it:
-
-  - A following ``Mc`` (`Spacing Combining Mark`_, e.g. a vowel sign) counts as
-    1 cell and closes the conjunct.
-  - A following character with positive width (or end of string) adds 1 cell
-    for the conjunct before counting its own width.
-
-- Chains work the same way: C + virama + C + virama + C collapses each
-  virama+consonant pair.
+- A ``Virama`` contributes 0 width (category ``Mn``).
+- A ``Consonant`` immediately following a ``Virama`` adds its width to the
+  current grapheme cluster.
+- The cluster total is capped at 2 cells (see `Grapheme Cluster Width Cap`_).
 - ``Mn`` marks do not break conjunct context within the same `aksara`_.
 - ZWJ (`U+200D`_) after a virama is consumed without breaking conjunct state,
   supporting explicit half-form requests (virama + ZWJ + consonant).

--- a/docs/specs.rst
+++ b/docs/specs.rst
@@ -111,7 +111,7 @@ reflecting its *positive advance width* as defined in `General Category`_
 and the ``Mc`` do not break the association. For example, a consonant followed
 by a Nukta (``Mn``) and then a vowel sign (``Mc``) is measured as base + 1.
 
-Any grapheme cluster width is limisted to 2 cells beginning release 0.8.0 (`PR #224`_).
+Any grapheme cluster width is limisted to 2 cells since 0.8.0, `PR #224`_.
 
 Virama Conjunct Formation
 -------------------------
@@ -126,7 +126,7 @@ described in the Virama section header).
 - A ``Virama`` contributes 0 width (category ``Mn``).
 - A ``Consonant`` immediately following a ``Virama`` adds its width to the
   current grapheme cluster.
-- The cluster total is capped at 2 cells (see `Grapheme Cluster Width Cap`_).
+- The cluster total is capped at 2 cells since 0.8.0, `PR #224`_.
 - ``Mn`` marks do not break conjunct context within the same `aksara`_.
 - ZWJ (`U+200D`_) after a virama is consumed without breaking conjunct state,
   supporting explicit half-form requests (virama + ZWJ + consonant).

--- a/docs/specs.rst
+++ b/docs/specs.rst
@@ -111,8 +111,7 @@ reflecting its *positive advance width* as defined in `General Category`_
 and the ``Mc`` do not break the association. For example, a consonant followed
 by a Nukta (``Mn``) and then a vowel sign (``Mc``) is measured as base + 1.
 
-All grapheme cluster widths are capped at 2 cells beginning release 0.8.0, matching
-behavior of the current grapheme-supporting terminals.
+Any grapheme cluster width is limisted to 2 cells beginning release 0.8.0 (`PR #224`_).
 
 Virama Conjunct Formation
 -------------------------
@@ -184,3 +183,4 @@ See also: `L2/2023/23107`_ "Proper Complex Script Support in Text Terminals".
 .. _`L2/2023/23107`: https://www.unicode.org/L2/L2023/23107-terminal-suppt.pdf
 .. _`Unicode Standard Annex #29`: https://www.unicode.org/reports/tr29/
 .. _`uncodedata.iter_graphemes()`: https://docs.python.org/3.15/library/unicodedata.html#unicodedata.iter_graphemes
+.. _`PR #224`: https://github.com/jquast/wcwidth/pull/224

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -308,8 +308,8 @@ def test_devanagari_script():
               "\u093F")   # MatraL, Category 'Mc', East Asian Width property 'N' -- DEVANAGARI VOWEL SIGN I
     # 23107-terminal-suppt.pdf suggests wcwidth.wcwidth should return (2, 0, 0, 1)
     expect_length_each = (1, 0, 1, 0)
-    # virama conjunct collapses KA+virama+SSA into one cell, Mc adds +1
-    expect_length_phrase = 3
+    # grapheme cluster capped at 2 cells (ghostty, foot, Windows Terminal)
+    expect_length_phrase = 2
 
     # exercise,
     length_each = tuple(map(wcwidth.wcwidth, phrase))
@@ -330,8 +330,8 @@ def test_tamil_script():
     # 23107-terminal-suppt.pdf suggests wcwidth.wcwidth should return (3, 0, 0, 4)
     expect_length_each = (1, 0, 1, 0)
 
-    # virama conjunct collapses KA+virama+SSA into one cell, Mc adds +1
-    expect_length_phrase = 3
+    # grapheme cluster capped at 2 cells (ghostty, foot, Windows Terminal)
+    expect_length_phrase = 2
 
     # exercise,
     length_each = tuple(map(wcwidth.wcwidth, phrase))
@@ -353,8 +353,8 @@ def test_kannada_script():
               "\u0cc8")   # MatraUR, Category 'Mc', East Asian Width property 'N' -- KANNADA VOWEL SIGN AI
     # 23107-terminal-suppt.pdf suggests should be (2, 0, 3, 1)
     expect_length_each = (1, 0, 1, 0)
-    # virama conjunct collapses RA+virama+JHA into one cell, Mc adds +1
-    expect_length_phrase = 3
+    # grapheme cluster capped at 2 cells (ghostty, foot, Windows Terminal)
+    expect_length_phrase = 2
 
     # exercise,
     length_each = tuple(map(wcwidth.wcwidth, phrase))
@@ -437,16 +437,16 @@ def test_mc_width_consistency(repeat):
 
 
 @pytest.mark.parametrize("phrase,expected", [
-    ("\u0999\u09CD\u0997\u09C7", 3),
-    ("\u0915\u094D\u0924\u093F", 3),
-    ("\u0915\u094D\u0930\u093F", 3),
-    ("\u0A95\u0ACD\u0A95\u0ACB", 3),
-    ("\u0938\u094D\u0924\u094D\u0930", 3),
+    ("\u0999\u09CD\u0997\u09C7", 2),
+    ("\u0915\u094D\u0924\u093F", 2),
+    ("\u0915\u094D\u0930\u093F", 2),
+    ("\u0A95\u0ACD\u0A95\u0ACB", 2),
+    ("\u0938\u094D\u0924\u094D\u0930", 2),
     ("\u0938\u094D\u0924", 2),
     ("\u0915\u094D\u0020", 2),
     ("\u09A4\u09CD\u200D\u09AA", 2),
     ("\u0915\u094D\u200D\u0924", 2),
-    ("\u0D15\u0D4D\u0D15\u0D41\u0D02", 3),
+    ("\u0D15\u0D4D\u0D15\u0D41\u0D02", 2),
     ("\u0915\u094D\u0924\u0941\u0902", 2),
 ])
 def test_virama_conjunct(phrase, expected):
@@ -456,9 +456,9 @@ def test_virama_conjunct(phrase, expected):
 
 @pytest.mark.parametrize("phrase,expected", [
     ("\u1000\u1039\u1000", 2),             # Burmese KA+VIRAMA+KA
-    ("\u1000\u1039\u1000\u1039\u1002", 3),  # Burmese KA+V+KA+V+GA
+    ("\u1000\u1039\u1000\u1039\u1002", 2),  # Burmese KA+V+KA+V+GA (capped)
     ("\u1000\u1039\u200D\u1000", 2),       # Burmese KA+V+ZWJ+KA
-    ("\u1782\u17D2\u1782\u17C1", 3),       # Khmer KO+COENG+KO+VOWEL_E (Mc closes)
+    ("\u1782\u17D2\u1782\u17C1", 2),       # Khmer KO+COENG+KO+VOWEL_E (capped)
     ("\u1780\u17D2\u1780", 2),             # Khmer KA+COENG+KA
 ])
 def test_virama_conjunct_invisible_stacker(phrase, expected):

--- a/tests/test_text_sizing.py
+++ b/tests/test_text_sizing.py
@@ -155,6 +155,7 @@ def test_text_sizing_sequence(given_sequence, expected_text, expected_params, ex
     ('\x1b]66;w=2;A\x07\x1b]66;w=3;B\x07', 5),
     ('\x1b]66;s=2:w=3;text\x1b\\', 6),
     ('\x1b[31m\x1b]66;w=2;AB\x07\x1b[0m', 2),
+    ('\x1b]66;;\x01\x07', 0),
 ])
 def test_strings_with_text_sizing(text, expected):
     """Verify measured width strings containing OSC66."""

--- a/tests/test_width.py
+++ b/tests/test_width.py
@@ -170,6 +170,9 @@ EDGE_CASES = [
     ('\x1b', 0, 'lone_ESC'),
     ('\x1b!', 1, 'ESC_unrecognized'),
     ('*\x1b*', 2, 'lone_ESC_between_text'),
+    ('\tA\u0CBE\rB\u0CBE\b', 10, 'backspace_flush_below_max_extent'),
+    ('\tA\u0CBE\rB\u0CBE\x1b', 10, 'esc_flush_below_max_extent'),
+    ('\tA\u0CBE\rB\u0CBE\x00', 10, 'zero_width_flush_below_max_extent'),
 ]
 
 

--- a/tests/test_width.py
+++ b/tests/test_width.py
@@ -173,6 +173,8 @@ EDGE_CASES = [
     ('\tA\u0CBE\rB\u0CBE\b', 10, 'backspace_flush_below_max_extent'),
     ('\tA\u0CBE\rB\u0CBE\x1b', 10, 'esc_flush_below_max_extent'),
     ('\tA\u0CBE\rB\u0CBE\x00', 10, 'zero_width_flush_below_max_extent'),
+    ('\tA\u0CBE\rB\u0CBE\x01', 10, 'illegal_ctrl_flush_below_max_extent'),
+    ('\tA\u0CBE\rB\u0CBE\n', 10, 'vertical_ctrl_flush_below_max_extent'),
 ]
 
 

--- a/tests/test_width.py
+++ b/tests/test_width.py
@@ -175,6 +175,7 @@ EDGE_CASES = [
     ('\tA\u0CBE\rB\u0CBE\x00', 10, 'zero_width_flush_below_max_extent'),
     ('\tA\u0CBE\rB\u0CBE\x01', 10, 'illegal_ctrl_flush_below_max_extent'),
     ('\tA\u0CBE\rB\u0CBE\n', 10, 'vertical_ctrl_flush_below_max_extent'),
+    ('\u4e2d\u0bcd\u4e2d\u0bcd\u4e2d\u0bcd\u4e2d', 2, 'glitch_virama_chain_capped'),
 ]
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -208,7 +208,7 @@ warn_unused_ignores = true
 [testenv:codespell]
 basepython = python3.14
 deps = codespell
-commands = codespell --skip="*.pyc,htmlcov,_build,build,*.egg-info,.tox,data,./tests/*.txt,*.csv,*.ods,table_*.py,docs/specs.rst,*.isorted" \
+commands = codespell --skip="*.pyc,htmlcov,_build,build,*.egg-info,.tox,data,./tests/*.txt,*.csv,*.ods,table_*.py,docs/specs.rst,*.isorted,ucs-detect" \
                      --ignore-words-list="thirdparty,claus,oclock,womens,aprox" \
                      --uri-ignore-words-list '*' \
                      --summary --count

--- a/wcwidth/_clip.py
+++ b/wcwidth/_clip.py
@@ -605,7 +605,9 @@ def _clip_painter(
                         f"{n_backward} cells left from column {col}, "
                         f"exceeding string start"
                     )
-                col = max(0, col - n_backward)
+                col -= n_backward
+                if col < 0:
+                    col = 0
                 idx = m.end()
                 continue
 

--- a/wcwidth/_wcswidth.py
+++ b/wcwidth/_wcswidth.py
@@ -73,6 +73,7 @@ def wcswidth(
     last_measured_idx = -2
     last_measured_ucs = -1
     prev_was_virama = False
+    cluster_width = 0
 
     while idx < end:
         char = pwcs[idx]
@@ -96,10 +97,11 @@ def wcswidth(
 
         # 6. VS16 (U+FE0F): converts preceding narrow character to wide.
         if ucs == 0xFE0F and last_measured_idx >= 0:
-            total_width += bisearch(
+            if bisearch(
                 ord(pwcs[last_measured_idx]),
                 VS16_NARROW_TO_WIDE['9.0.0'],
-            )
+            ):
+                cluster_width = 2
             last_measured_idx = -2  # prevent double application
             idx += 1
             continue
@@ -127,17 +129,25 @@ def wcswidth(
             # C0/C1 control character
             return -1
         if w > 0:
-            total_width += w
+            # virama+consonant extends current cluster; otherwise start new
+            if prev_was_virama:
+                cluster_width += w
+            else:
+                if cluster_width:
+                    total_width += cluster_width if cluster_width < 2 else 2
+                cluster_width = w
             last_measured_idx = idx
             last_measured_ucs = ucs
             prev_was_virama = False
         elif last_measured_idx >= 0 and bisearch(ucs, _CATEGORY_MC_TABLE):
-            # Spacing Combining Mark (Mc) following a base character adds 1
-            total_width += 1
+            # Spacing Combining Mark (Mc) following a base character
+            cluster_width += 1
             last_measured_idx = -2
             prev_was_virama = False
         else:
             prev_was_virama = ucs in _ISC_VIRAMA_SET
         idx += 1
 
+    if cluster_width:
+        total_width += cluster_width if cluster_width < 2 else 2
     return total_width

--- a/wcwidth/_wcswidth.py
+++ b/wcwidth/_wcswidth.py
@@ -74,7 +74,7 @@ def wcswidth(
     last_measured_ucs = -1
     prev_was_virama = False
     cluster_width = 0
-    _VS16_TABLE = VS16_NARROW_TO_WIDE['9.0.0']
+    vs16_nw_table = VS16_NARROW_TO_WIDE['9.0.0']
     _bisearch = bisearch
 
     while idx < end:
@@ -99,7 +99,7 @@ def wcswidth(
 
         # 6. VS16 (U+FE0F): converts preceding narrow character to wide.
         if ucs == 0xFE0F and last_measured_idx >= 0:
-            if _bisearch(last_measured_ucs, _VS16_TABLE):
+            if _bisearch(last_measured_ucs, vs16_nw_table):
                 cluster_width = 2
             last_measured_idx = -2  # prevent double application
             idx += 1

--- a/wcwidth/_wcswidth.py
+++ b/wcwidth/_wcswidth.py
@@ -76,7 +76,8 @@ def wcswidth(
     cluster_width = 0
     vs16_nw_table = VS16_NARROW_TO_WIDE['9.0.0']
     _bisearch = bisearch
-    _cap2 = (0, 1, 2, 2, 2, 2, 2)
+    _cap2 = (0, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+             2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2)
 
     while idx < end:
         char = pwcs[idx]

--- a/wcwidth/_wcswidth.py
+++ b/wcwidth/_wcswidth.py
@@ -76,8 +76,6 @@ def wcswidth(
     cluster_width = 0
     vs16_nw_table = VS16_NARROW_TO_WIDE['9.0.0']
     _bisearch = bisearch
-    _cap2 = (0, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-             2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2)
 
     while idx < end:
         char = pwcs[idx]
@@ -132,17 +130,17 @@ def wcswidth(
         if w > 0:
             # virama+consonant extends current cluster; otherwise start new
             if prev_was_virama:
-                cluster_width += w
+                cluster_width = 2
             else:
                 if cluster_width:
-                    total_width += _cap2[cluster_width]
+                    total_width += cluster_width
                 cluster_width = w
             last_measured_idx = idx
             last_measured_ucs = ucs
             prev_was_virama = False
         elif last_measured_idx >= 0 and _bisearch(ucs, _CATEGORY_MC_TABLE):
             # Spacing Combining Mark (Mc) following a base character
-            cluster_width += 1
+            cluster_width = 2
             last_measured_idx = -2
             prev_was_virama = False
         else:
@@ -150,5 +148,5 @@ def wcswidth(
         idx += 1
 
     if cluster_width:
-        total_width += _cap2[cluster_width]
+        total_width += cluster_width
     return total_width

--- a/wcwidth/_wcswidth.py
+++ b/wcwidth/_wcswidth.py
@@ -69,11 +69,13 @@ def wcswidth(
     total_width = 0
     idx = 0
 
-    # grapheme-clustering state
+    # grapheme-clustering state and local re-binding for performance
     last_measured_idx = -2
     last_measured_ucs = -1
     prev_was_virama = False
     cluster_width = 0
+    _VS16_TABLE = VS16_NARROW_TO_WIDE['9.0.0']
+    _bisearch = bisearch
 
     while idx < end:
         char = pwcs[idx]
@@ -97,10 +99,7 @@ def wcswidth(
 
         # 6. VS16 (U+FE0F): converts preceding narrow character to wide.
         if ucs == 0xFE0F and last_measured_idx >= 0:
-            if bisearch(
-                ord(pwcs[last_measured_idx]),
-                VS16_NARROW_TO_WIDE['9.0.0'],
-            ):
+            if _bisearch(last_measured_ucs, _VS16_TABLE):
                 cluster_width = 2
             last_measured_idx = -2  # prevent double application
             idx += 1
@@ -139,7 +138,7 @@ def wcswidth(
             last_measured_idx = idx
             last_measured_ucs = ucs
             prev_was_virama = False
-        elif last_measured_idx >= 0 and bisearch(ucs, _CATEGORY_MC_TABLE):
+        elif last_measured_idx >= 0 and _bisearch(ucs, _CATEGORY_MC_TABLE):
             # Spacing Combining Mark (Mc) following a base character
             cluster_width += 1
             last_measured_idx = -2

--- a/wcwidth/_wcswidth.py
+++ b/wcwidth/_wcswidth.py
@@ -76,6 +76,7 @@ def wcswidth(
     cluster_width = 0
     vs16_nw_table = VS16_NARROW_TO_WIDE['9.0.0']
     _bisearch = bisearch
+    _cap2 = (0, 1, 2, 2, 2, 2, 2)
 
     while idx < end:
         char = pwcs[idx]
@@ -133,7 +134,7 @@ def wcswidth(
                 cluster_width += w
             else:
                 if cluster_width:
-                    total_width += cluster_width if cluster_width < 2 else 2
+                    total_width += _cap2[cluster_width]
                 cluster_width = w
             last_measured_idx = idx
             last_measured_ucs = ucs
@@ -148,5 +149,5 @@ def wcswidth(
         idx += 1
 
     if cluster_width:
-        total_width += cluster_width if cluster_width < 2 else 2
+        total_width += _cap2[cluster_width]
     return total_width

--- a/wcwidth/_width.py
+++ b/wcwidth/_width.py
@@ -170,12 +170,19 @@ def width(
     last_measured_idx = -2
     last_measured_ucs = -1
     prev_was_virama = False
+    cluster_width = 0
 
     while idx < text_len:
         char = text[idx]
 
         # 1. ESC sequences
         if char == '\x1b':
+            # Flush pending cluster before processing escape sequence
+            if cluster_width:
+                current_col += cluster_width if cluster_width < 2 else 2
+                if current_col > max_extent:
+                    max_extent = current_col
+                cluster_width = 0
             m = _SEQUENCE_CLASSIFY.match(text, idx)
             if not m:
                 # 1a. Errant ESC or unknown sequence: only the first character is zero-width
@@ -221,13 +228,19 @@ def width(
             # Escape sequences break VS16 adjacency: reset last-measured state
             last_measured_idx = -2
             last_measured_ucs = -1
-            max_extent = max(max_extent, current_col)
+            if current_col > max_extent:
+                max_extent = current_col
             continue
 
         # 2. Vertical or Illegal control characters zero width or error when 'strict'
         if char in ILLEGAL_CTRL:
             if strict:
                 raise ValueError(f"Illegal control character {ord(char):#x} at position {idx}")
+            if cluster_width:
+                current_col += cluster_width if cluster_width < 2 else 2
+                if current_col > max_extent:
+                    max_extent = current_col
+                cluster_width = 0
             idx += 1
             last_measured_idx = -2
             last_measured_ucs = -1
@@ -236,6 +249,11 @@ def width(
         if char in VERTICAL_CTRL:
             if strict:
                 raise ValueError(f"Vertical movement character {ord(char):#x} at position {idx}")
+            if cluster_width:
+                current_col += cluster_width if cluster_width < 2 else 2
+                if current_col > max_extent:
+                    max_extent = current_col
+                cluster_width = 0
             idx += 1
             last_measured_idx = -2
             last_measured_ucs = -1
@@ -243,6 +261,11 @@ def width(
 
         # 3. Horizontal movement characters
         if char in HORIZONTAL_CTRL:
+            if cluster_width:
+                current_col += cluster_width if cluster_width < 2 else 2
+                if current_col > max_extent:
+                    max_extent = current_col
+                cluster_width = 0
             if char == '\t' and tabsize > 0:
                 current_col += tabsize - (current_col % tabsize)
             elif char == '\b':
@@ -255,7 +278,8 @@ def width(
                         "indeterminate starting column"
                     )
                 current_col = 0
-            max_extent = max(max_extent, current_col)
+            if current_col > max_extent:
+                max_extent = current_col
             idx += 1
             last_measured_idx = -2
             last_measured_ucs = -1
@@ -263,6 +287,11 @@ def width(
 
         # 4. Zero-width control characters
         if char in ZERO_WIDTH_CTRL:
+            if cluster_width:
+                current_col += cluster_width if cluster_width < 2 else 2
+                if current_col > max_extent:
+                    max_extent = current_col
+                cluster_width = 0
             idx += 1
             last_measured_idx = -2
             last_measured_ucs = -1
@@ -287,8 +316,7 @@ def width(
         # 6. VS16 (U+FE0F): converts preceding narrow character to wide.
         if ucs == 0xFE0F and last_measured_idx >= 0:
             if bisearch(ord(text[last_measured_idx]), VS16_NARROW_TO_WIDE['9.0.0']):
-                current_col += 1
-                max_extent = max(max_extent, current_col)
+                cluster_width = 2
             last_measured_idx = -2  # prevent double application
             idx += 1
             continue
@@ -313,19 +341,29 @@ def width(
         # 8. Normal character: measure with wcwidth
         w = _wcwidth(char)
         if w > 0:
-            current_col += w
-            max_extent = max(max_extent, current_col)
+            # virama+consonant extends current cluster; otherwise start new
+            if prev_was_virama:
+                cluster_width += w
+            else:
+                if cluster_width:
+                    current_col += cluster_width if cluster_width < 2 else 2
+                    if current_col > max_extent:
+                        max_extent = current_col
+                cluster_width = w
             last_measured_idx = idx
             last_measured_ucs = ucs
             prev_was_virama = False
         elif last_measured_idx >= 0 and bisearch(ucs, _CATEGORY_MC_TABLE):
-            # Spacing Combining Mark (Mc) following a base character adds 1
-            current_col += 1
-            max_extent = max(max_extent, current_col)
+            # Spacing Combining Mark (Mc) following a base character
+            cluster_width += 1
             last_measured_idx = -2
             prev_was_virama = False
         else:
             prev_was_virama = ucs in _ISC_VIRAMA_SET
         idx += 1
 
+    if cluster_width:
+        current_col += cluster_width if cluster_width < 2 else 2
+        if current_col > max_extent:
+            max_extent = current_col
     return max_extent

--- a/wcwidth/_width.py
+++ b/wcwidth/_width.py
@@ -173,7 +173,8 @@ def width(
     cluster_width = 0
     vs16_nw_table = VS16_NARROW_TO_WIDE['9.0.0']
     _bisearch = bisearch
-    _cap2 = (0, 1, 2, 2, 2, 2, 2)
+    _cap2 = (0, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+             2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2)
 
     while idx < text_len:
         char = text[idx]

--- a/wcwidth/_width.py
+++ b/wcwidth/_width.py
@@ -213,7 +213,9 @@ def width(
                             f"{n_backward} cells left from column {current_col}, "
                             f"exceeding string start"
                         )
-                    current_col = max(0, current_col - n_backward)
+                    current_col -= n_backward
+                    if current_col < 0:
+                        current_col = 0
                 # 2d. OSC 66 Text Sizing — has positive display width
                 elif (ts_meta := m.group('ts_meta')) is not None:
                     ts_text = m.group('ts_text')

--- a/wcwidth/_width.py
+++ b/wcwidth/_width.py
@@ -173,8 +173,6 @@ def width(
     cluster_width = 0
     vs16_nw_table = VS16_NARROW_TO_WIDE['9.0.0']
     _bisearch = bisearch
-    _cap2 = (0, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-             2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2)
 
     while idx < text_len:
         char = text[idx]
@@ -183,7 +181,7 @@ def width(
         if char == '\x1b':
             # Flush pending cluster before processing escape sequence
             if cluster_width:
-                current_col += _cap2[cluster_width]
+                current_col += cluster_width
                 if current_col > max_extent:
                     max_extent = current_col
                 cluster_width = 0
@@ -243,7 +241,7 @@ def width(
             if strict:
                 raise ValueError(f"Illegal control character {ord(char):#x} at position {idx}")
             if cluster_width:
-                current_col += _cap2[cluster_width]
+                current_col += cluster_width
                 if current_col > max_extent:
                     max_extent = current_col
                 cluster_width = 0
@@ -256,7 +254,7 @@ def width(
             if strict:
                 raise ValueError(f"Vertical movement character {ord(char):#x} at position {idx}")
             if cluster_width:
-                current_col += _cap2[cluster_width]
+                current_col += cluster_width
                 if current_col > max_extent:
                     max_extent = current_col
                 cluster_width = 0
@@ -268,7 +266,7 @@ def width(
         # 3. Horizontal movement characters
         if char in HORIZONTAL_CTRL:
             if cluster_width:
-                current_col += _cap2[cluster_width]
+                current_col += cluster_width
                 if current_col > max_extent:
                     max_extent = current_col
                 cluster_width = 0
@@ -294,7 +292,7 @@ def width(
         # 4. Zero-width control characters
         if char in ZERO_WIDTH_CTRL:
             if cluster_width:
-                current_col += _cap2[cluster_width]
+                current_col += cluster_width
                 if current_col > max_extent:
                     max_extent = current_col
                 cluster_width = 0
@@ -349,10 +347,10 @@ def width(
         if w > 0:
             # virama+consonant extends current cluster; otherwise start new
             if prev_was_virama:
-                cluster_width += w
+                cluster_width = 2
             else:
                 if cluster_width:
-                    current_col += _cap2[cluster_width]
+                    current_col += cluster_width
                     if current_col > max_extent:
                         max_extent = current_col
                 cluster_width = w
@@ -361,7 +359,7 @@ def width(
             prev_was_virama = False
         elif last_measured_idx >= 0 and _bisearch(ucs, _CATEGORY_MC_TABLE):
             # Spacing Combining Mark (Mc) following a base character
-            cluster_width += 1
+            cluster_width = 2
             last_measured_idx = -2
             prev_was_virama = False
         else:
@@ -369,7 +367,7 @@ def width(
         idx += 1
 
     if cluster_width:
-        current_col += _cap2[cluster_width]
+        current_col += cluster_width
         if current_col > max_extent:
             max_extent = current_col
     return max_extent

--- a/wcwidth/_width.py
+++ b/wcwidth/_width.py
@@ -173,6 +173,7 @@ def width(
     cluster_width = 0
     vs16_nw_table = VS16_NARROW_TO_WIDE['9.0.0']
     _bisearch = bisearch
+    _cap2 = (0, 1, 2, 2, 2, 2, 2)
 
     while idx < text_len:
         char = text[idx]
@@ -181,7 +182,7 @@ def width(
         if char == '\x1b':
             # Flush pending cluster before processing escape sequence
             if cluster_width:
-                current_col += cluster_width if cluster_width < 2 else 2
+                current_col += _cap2[cluster_width]
                 if current_col > max_extent:
                     max_extent = current_col
                 cluster_width = 0
@@ -241,7 +242,7 @@ def width(
             if strict:
                 raise ValueError(f"Illegal control character {ord(char):#x} at position {idx}")
             if cluster_width:
-                current_col += cluster_width if cluster_width < 2 else 2
+                current_col += _cap2[cluster_width]
                 if current_col > max_extent:
                     max_extent = current_col
                 cluster_width = 0
@@ -254,7 +255,7 @@ def width(
             if strict:
                 raise ValueError(f"Vertical movement character {ord(char):#x} at position {idx}")
             if cluster_width:
-                current_col += cluster_width if cluster_width < 2 else 2
+                current_col += _cap2[cluster_width]
                 if current_col > max_extent:
                     max_extent = current_col
                 cluster_width = 0
@@ -266,7 +267,7 @@ def width(
         # 3. Horizontal movement characters
         if char in HORIZONTAL_CTRL:
             if cluster_width:
-                current_col += cluster_width if cluster_width < 2 else 2
+                current_col += _cap2[cluster_width]
                 if current_col > max_extent:
                     max_extent = current_col
                 cluster_width = 0
@@ -292,7 +293,7 @@ def width(
         # 4. Zero-width control characters
         if char in ZERO_WIDTH_CTRL:
             if cluster_width:
-                current_col += cluster_width if cluster_width < 2 else 2
+                current_col += _cap2[cluster_width]
                 if current_col > max_extent:
                     max_extent = current_col
                 cluster_width = 0
@@ -350,7 +351,7 @@ def width(
                 cluster_width += w
             else:
                 if cluster_width:
-                    current_col += cluster_width if cluster_width < 2 else 2
+                    current_col += _cap2[cluster_width]
                     if current_col > max_extent:
                         max_extent = current_col
                 cluster_width = w
@@ -367,7 +368,7 @@ def width(
         idx += 1
 
     if cluster_width:
-        current_col += cluster_width if cluster_width < 2 else 2
+        current_col += _cap2[cluster_width]
         if current_col > max_extent:
             max_extent = current_col
     return max_extent

--- a/wcwidth/_width.py
+++ b/wcwidth/_width.py
@@ -171,7 +171,7 @@ def width(
     last_measured_ucs = -1
     prev_was_virama = False
     cluster_width = 0
-    _VS16_TABLE = VS16_NARROW_TO_WIDE['9.0.0']
+    vs16_nw_table = VS16_NARROW_TO_WIDE['9.0.0']
     _bisearch = bisearch
 
     while idx < text_len:
@@ -319,7 +319,7 @@ def width(
 
         # 6. VS16 (U+FE0F): converts preceding narrow character to wide.
         if ucs == 0xFE0F and last_measured_idx >= 0:
-            if _bisearch(last_measured_ucs, _VS16_TABLE):
+            if _bisearch(last_measured_ucs, vs16_nw_table):
                 cluster_width = 2
             last_measured_idx = -2  # prevent double application
             idx += 1

--- a/wcwidth/_width.py
+++ b/wcwidth/_width.py
@@ -166,11 +166,13 @@ def width(
     # - ambiguous_width=2: full positional args needed (results differ, separate cache is correct)
     _wcwidth = wcwidth if ambiguous_width == 1 else lambda c: wcwidth(c, 'auto', ambiguous_width)
 
-    # grapheme-clustering state
+    # grapheme-clustering state and local re-bindings for performance
     last_measured_idx = -2
     last_measured_ucs = -1
     prev_was_virama = False
     cluster_width = 0
+    _VS16_TABLE = VS16_NARROW_TO_WIDE['9.0.0']
+    _bisearch = bisearch
 
     while idx < text_len:
         char = text[idx]
@@ -317,7 +319,7 @@ def width(
 
         # 6. VS16 (U+FE0F): converts preceding narrow character to wide.
         if ucs == 0xFE0F and last_measured_idx >= 0:
-            if bisearch(ord(text[last_measured_idx]), VS16_NARROW_TO_WIDE['9.0.0']):
+            if _bisearch(last_measured_ucs, _VS16_TABLE):
                 cluster_width = 2
             last_measured_idx = -2  # prevent double application
             idx += 1
@@ -355,7 +357,7 @@ def width(
             last_measured_idx = idx
             last_measured_ucs = ucs
             prev_was_virama = False
-        elif last_measured_idx >= 0 and bisearch(ucs, _CATEGORY_MC_TABLE):
+        elif last_measured_idx >= 0 and _bisearch(ucs, _CATEGORY_MC_TABLE):
             # Spacing Combining Mark (Mc) following a base character
             cluster_width += 1
             last_measured_idx = -2

--- a/wcwidth/text_sizing.py
+++ b/wcwidth/text_sizing.py
@@ -193,7 +193,9 @@ class TextSizing(typing.NamedTuple):
         if self.params.width > 0:
             return self.params.scale * self.params.width
         w = wcswidth(self.text, ambiguous_width=ambiguous_width)
-        return self.params.scale * max(0, w)
+        if w < 0:
+            w = 0
+        return self.params.scale * w
 
     def make_sequence(self) -> str:
         """Build and return complete OSC 66 Terminal Sequence."""


### PR DESCRIPTION
From, https://github.com/ghostty-org/ghostty/pull/10465#issuecomment-4628042273

ghostty, foot, and windows terminal all clip all final grapheme widths to 2 cells for cursor advance.

Even though they "spill" out and over adjacent cells, the measurement of cursor advance is limited to 2 by their engines.

ghostty (2):
<img width="800" height="228" alt="image" src="https://github.com/user-attachments/assets/00821b21-97c0-4a69-a196-a6fe2a8c548d" />

foot (2):
<img width="1024" height="159" alt="image" src="https://github.com/user-attachments/assets/a6106e6c-5519-4498-9a7d-fa28dc256787" />
