### PR TITLE
fix: clamp n to len(pwcs) in wcswidth/wcstwidth to avoid IndexError

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -499,10 +499,10 @@ def test_zwj_at_end_of_string():
 
 def test_wcswidth_n_exceeds_length():
     """
-    wcswidth() with n > len(string) returns same as n=None.
+    Wcswidth() with n > len(string) returns same as n=None.
 
-    Passing n larger than the string length should not raise IndexError;
-    it should behave identically to measuring the whole string.
+    Passing n larger than the string length should not raise IndexError; it should behave
+    identically to measuring the whole string.
     """
     # ASCII string
     assert wcwidth.wcswidth('hello', 10) == 5
@@ -511,6 +511,7 @@ def test_wcswidth_n_exceeds_length():
     # ZWJ cluster
     family = '\U0001F468\u200D\U0001F469\u200D\U0001F467'
     assert wcwidth.wcswidth(family, len(family) + 1) == wcwidth.wcswidth(family)
+    assert wcwidth.wcstwidth(family, len(family) + 1) == wcwidth.wcstwidth(family)
 
 
 def test_soft_hyphen():

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -497,6 +497,22 @@ def test_zwj_at_end_of_string():
     assert wcwidth.wcswidth('a\u200D') == 1
 
 
+def test_wcswidth_n_exceeds_length():
+    """
+    wcswidth() with n > len(string) returns same as n=None.
+
+    Passing n larger than the string length should not raise IndexError;
+    it should behave identically to measuring the whole string.
+    """
+    # ASCII string
+    assert wcwidth.wcswidth('hello', 10) == 5
+    # Wide characters
+    assert wcwidth.wcswidth('\u30B3\u30F3', 5) == 4
+    # ZWJ cluster
+    family = '\U0001F468\u200D\U0001F469\u200D\U0001F467'
+    assert wcwidth.wcswidth(family, len(family) + 1) == wcwidth.wcswidth(family)
+
+
 def test_soft_hyphen():
     # Test SOFT HYPHEN, category 'Cf' usually are zero-width, but most
     # implementations agree to draw it was '1' cell, visually

--- a/tests/test_term_overrides.py
+++ b/tests/test_term_overrides.py
@@ -418,6 +418,13 @@ def test_get_term_overrides_narrow_wider_still_empty():
     assert overrides.narrow_wider == ()
 
 
+@pytest.mark.parametrize('func', [wcwidth.wcstwidth, wcwidth.width])
+def test_narrow_wider_width(func):
+    """Width() matches wcstwidth() for narrow_wider overrides."""
+    assert wcwidth.wcswidth('\u261d') == 1
+    assert func('\u261d', term_program='kitty') == 2
+
+
 @pytest.mark.parametrize('codepoint', [
     '\u00ad',
     '\u0600',

--- a/wcwidth/_wcswidth.py
+++ b/wcwidth/_wcswidth.py
@@ -98,7 +98,7 @@ def wcswidth(
 
     _wcwidth = wcwidth if ambiguous_width == 1 else lambda c: wcwidth(c, 'auto', ambiguous_width)
 
-    end = len(pwcs) if n is None else n
+    end = len(pwcs) if n is None else min(n, len(pwcs))
     total_width = 0
     idx = 0
 
@@ -262,7 +262,7 @@ def wcstwidth(
     # Select wcwidth call pattern for best lru_cache performance
     _wcwidth = wcwidth if ambiguous_width == 1 else lambda c: wcwidth(c, 'auto', ambiguous_width)
 
-    end = len(pwcs) if n is None else n
+    end = len(pwcs) if n is None else min(n, len(pwcs))
     total_width = 0
     idx = 0
 


### PR DESCRIPTION
## Bug

\`wcswidth()\` and \`wcstwidth()\` raise \`IndexError\` when the \`n\` parameter is larger than the length of the string.

\`\`\`python
>>> from wcwidth import wcswidth
>>> wcswidth('hello', 10)
IndexError: string index out of range
\`\`\`

**Root cause:** The \`end\` variable is set directly to \`n\`:

\`\`\`python
end = len(pwcs) if n is None else n
\`\`\`

When \`n > len(pwcs)\`, the \`while idx < end\` loop tries to access \`pwcs[idx]\` past the end of the string.

## Fix

Clamp \`end\` to \`len(pwcs)\`:

\`\`\`python
end = len(pwcs) if n is None else min(n, len(pwcs))
\`\`\`

This is the natural Python semantics for sized strings: \`n\` larger than the string length is equivalent to measuring the whole string. The same fix applies to \`wcstwidth()\`.

## Test

Added \`test_wcswidth_n_exceeds_length\` covering ASCII, wide characters, and ZWJ clusters.

\`\`\`
1316 passed, 10 skipped
\`\`\`