### PR TITLE
Fix hang wrapping OSC-8 hyperlinks with wide graphemes

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -654,6 +654,10 @@ languages:
 History
 =======
 
+0.8.3 *2026-07-22*
+  * **Bugfix** Do not hang on `wrap()`_ calls of width 1 with text containing OSC8 hyperlinks and
+    wide characters. `PR #231`_
+
 0.8.2 *2026-06-29*
   * **Bugfix** Do not raise IndexError when given legacy POSIX ``n`` argument to `wcswidth()`_ or
     `wcstwidth()`_ exceed string length without raising IndexError
@@ -911,6 +915,7 @@ https://www.cl.cam.ac.uk/~mgk25/ucs/wcwidth.c::
 .. _`PR #223`: https://github.com/jquast/wcwidth/pull/223
 .. _`PR #224`: https://github.com/jquast/wcwidth/pull/224
 .. _`PR #226`: https://github.com/jquast/wcwidth/pull/226
+.. _`PR #231`: https://github.com/jquast/wcwidth/pull/231
 .. _`Issue #101`: https://github.com/jquast/wcwidth/issues/101
 .. _`Issue #155`: https://github.com/jquast/wcwidth/issues/155
 .. _`Issue #190`: https://github.com/jquast/wcwidth/issues/190

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -480,8 +480,7 @@ recognized names:
 .. END_LIST_TERM_PROGRAMS
 
 ``term_program=False`` (the default for `width()`_, `ljust()`_, `rjust()`_, `center()`_,
-`wrap()`_, and `clip()`_) disables terminal corrections.  `wcstwidth()`_ defaults to
-``term_program=True`` for auto-detection.
+`wrap()`_, and `clip()`_) disables terminal corrections.
 
 For automatic tests and other purposes that require cross-environment consistency, set static values
 or unset ``TERM`` and ``TERM_PROGRAM`` environment values, such as in ``conftest.py`` with pytest:
@@ -659,8 +658,8 @@ History
     wide characters. `PR #231`_
 
 0.8.2 *2026-06-29*
-  * **Bugfix** Do not raise IndexError when given legacy POSIX ``n`` argument to `wcswidth()`_ or
-    `wcstwidth()`_ exceed string length without raising IndexError
+  * **Bugfix** Do not raise IndexError when legacy POSIX ``n`` argument to `wcswidth()`_ or
+    `wcstwidth()`_ exceeds the given string length. `PR #230`_
 
 0.8.1 *2026-06-08*
   * **Improved** `wcstwidth()`_ with new ``zeroer``, ``narrow_wider``, and ``narrow_zeroer``

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [ "hatchling" ]
 
 [project]
 name = "wcwidth"
-version = "0.8.2"  # don't forget to also update wcwidth/__init__.py:__version__
+version = "0.8.3"  # don't forget to also update wcwidth/__init__.py:__version__
 description = "Measures the displayed width of unicode strings in a terminal"
 readme = "README.rst"
 keywords = [

--- a/tests/test_textwrap.py
+++ b/tests/test_textwrap.py
@@ -501,3 +501,13 @@ def test_wrap_bare_esc():
     """Bare ESC not part of a recognized sequence is treated as zero-width."""
     assert wrap('ab\x1bcd ef', 5) == ['ab\x1bcd', 'ef']
     assert wrap('ab\x1b\x00cdef', 3) == ['ab\x1b\x00c', 'def']
+
+
+def test_wrap_bare_esc_at_line_start():
+    """
+    Exercises the bare-ESC safety break in _find_first_visible_break.
+
+    A bare \\x1b that does not match ZERO_WIDTH_PATTERN triggers a safety 'break' statement but is
+    not found in any practical terminal sequence or string (ESC followed by NUL).
+    """
+    assert wrap('\x1b\x00あ', 1) == ['\x1b', '\x00', 'あ']

--- a/tests/test_textwrap.py
+++ b/tests/test_textwrap.py
@@ -387,6 +387,16 @@ OSC_END_BEL = '\x1b]8;;\x07'
             '\x1b]8;foo=bar:id=mylink;http://example.com\x1b\\Click\x1b]8;;\x1b\\',
             '\x1b]8;foo=bar:id=mylink;http://example.com\x1b\\here\x1b]8;;\x1b\\',
         ],
+    ),
+    (   # wide grapheme after OSC 8 open at width 1 (must not hang)
+        '\x1b]8;;u\x07😀',
+        1,
+        ['\x1b]8;id=00000001;u\x07😀\x1b]8;;\x07'],
+    ),
+    (   # CJK wide char after OSC 8 open at width 1 (must not hang)
+        '\x1b]8;;u\x07あ',
+        1,
+        ['\x1b]8;id=00000001;u\x07あ\x1b]8;;\x07'],
     ),])
 def test_wrap_hyperlink_word_boundary(text, w, expected):
     """OSC hyperlink sequences should act as word boundaries."""

--- a/wcwidth/__init__.py
+++ b/wcwidth/__init__.py
@@ -78,4 +78,4 @@ __all__ = ('wcwidth', 'wcswidth', 'wcstwidth', 'width', 'iter_sequences', 'iter_
 # Using 'hatchling', it does not seem to provide the pyproject.toml nicety, "dynamic = ['version']"
 # like flit_core, maybe there is some better way but for now we have to duplicate it in both places
 # Prefer the installed distribution version when available (helps test environments)
-__version__ = '0.8.2'  # don't forget to also update pyproject.toml:version
+__version__ = '0.8.3'  # don't forget to also update pyproject.toml:version

--- a/wcwidth/textwrap.py
+++ b/wcwidth/textwrap.py
@@ -500,10 +500,6 @@ class SequenceTextWrapper(textwrap.TextWrapper):
         # exceeds and we return from within the loop. Type checker requires this.
         return idx  # pragma: no cover
 
-    def _find_first_grapheme_end(self, text: str) -> int:
-        """Find the end position of the first grapheme."""
-        return len(next(iter_graphemes(text)))
-
     def _find_first_visible_break(self, text: str) -> int:
         """End of leading escape sequences plus the first grapheme."""
         idx = 0

--- a/wcwidth/textwrap.py
+++ b/wcwidth/textwrap.py
@@ -508,8 +508,6 @@ class SequenceTextWrapper(textwrap.TextWrapper):
             if match is None:
                 break
             idx = match.end()
-        if idx >= len(text):
-            return len(text)
         return idx + len(next(iter_graphemes(text, start=idx)))
 
     def _rstrip_visible(self, text: str) -> str:

--- a/wcwidth/textwrap.py
+++ b/wcwidth/textwrap.py
@@ -440,12 +440,12 @@ class SequenceTextWrapper(textwrap.TextWrapper):
                 actual_end = hyphen_end
             else:
                 actual_end = self._find_break_position(chunk, space_left)
-                # If no progress possible (e.g., wide char exceeds line width),
-                # force at least one grapheme to avoid infinite loop.
-                # Only force when cur_line is empty; if line has content,
-                # appending nothing is safe and the line will be committed.
-                if actual_end == 0 and not cur_line:
-                    actual_end = self._find_first_grapheme_end(chunk)
+                # Include first visible unit when break would take only leading sequences.
+                if not cur_line and (
+                        actual_end == 0
+                        or (actual_end < len(chunk)
+                            and self._width(chunk[:actual_end]) == 0)):
+                    actual_end = self._find_first_visible_break(chunk)
             cur_line.append(chunk[:actual_end])
             reversed_chunks[-1] = chunk[actual_end:]
 
@@ -503,6 +503,18 @@ class SequenceTextWrapper(textwrap.TextWrapper):
     def _find_first_grapheme_end(self, text: str) -> int:
         """Find the end position of the first grapheme."""
         return len(next(iter_graphemes(text)))
+
+    def _find_first_visible_break(self, text: str) -> int:
+        """End of leading escape sequences plus the first grapheme."""
+        idx = 0
+        while idx < len(text) and text[idx] == '\x1b':
+            match = ZERO_WIDTH_PATTERN.match(text, idx)
+            if match is None:
+                break
+            idx = match.end()
+        if idx >= len(text):
+            return len(text)
+        return idx + len(next(iter_graphemes(text, start=idx)))
 
     def _rstrip_visible(self, text: str) -> str:
         """Strip trailing visible whitespace, preserving trailing sequences."""


### PR DESCRIPTION
Supersedes #231 with missing coverage, this statement caused ``wcwidth.wrap()`` to loop forever, reported and fixed by @santhreal:

```python
wcwidth.wrap('\x1b]8;;u\x07😀', 1)
```
