### PR TITLE
add twine_check to "tox -e lint" and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,11 @@ jobs:
             toxenv: mypy
             label: mypy
 
+          # Packaging metadata and README render
+          - python-version: '3.14'
+            toxenv: twine_check
+            label: twine check
+
     steps:
       - uses: actions/checkout@v6
         with:

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -647,7 +647,7 @@ History
   * **Bugfix** Do not hang on `wrap()`_ calls of width 1 with text containing OSC8 hyperlinks and
     wide characters, `PR #231`_.
   * **Bugfix** `clip()`_ with ``propagate_sgr=True``, should match behavior of `propagate_sgr()`_,
-    `PR #235`.
+    `PR #235`_.
 
 0.8.2 *2026-06-29*
   * **Bugfix** Do not raise IndexError when legacy POSIX ``n`` argument to `wcswidth()`_ or
@@ -906,6 +906,7 @@ https://www.cl.cam.ac.uk/~mgk25/ucs/wcwidth.c::
 .. _`PR #223`: https://github.com/jquast/wcwidth/pull/223
 .. _`PR #224`: https://github.com/jquast/wcwidth/pull/224
 .. _`PR #226`: https://github.com/jquast/wcwidth/pull/226
+.. _`PR #230`: https://github.com/jquast/wcwidth/pull/230
 .. _`PR #231`: https://github.com/jquast/wcwidth/pull/231
 .. _`PR #235`: https://github.com/jquast/wcwidth/pull/235
 .. _`Issue #101`: https://github.com/jquast/wcwidth/issues/101

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = update, fetch, compile, autopep8, docformatter, docformatter_check, isort, isort_check, pylint, pylint_tests, flake8, flake8_tests, pydocstyle, mypy, codespell, format, lint, docs, verify_tables, py{38, 39, 310, 311, 312, 313, 314}
+envlist = update, fetch, compile, autopep8, docformatter, docformatter_check, isort, isort_check, pylint, pylint_tests, flake8, flake8_tests, pydocstyle, mypy, codespell, twine_check, format, lint, docs, verify_tables, py{38, 39, 310, 311, 312, 313, 314}
 skip_missing_interpreters = true
 
 [base]
@@ -217,6 +217,18 @@ commands = codespell --skip="*.pyc,htmlcov,_build,build,*.egg-info,.tox,data,./t
                      --uri-ignore-words-list '*' \
                      --summary --count
 
+[testenv:twine_check]
+# Verify the built distributions the way upload.pypi.org does: 'twine check'
+# runs the README through readme_renderer, which halts on any reStructuredText
+# error (such as a reference with no matching target).  Neither doc8 (D000 is
+# disabled) nor the python linters inspect README.rst.
+basepython = python3.14
+skip_install = true
+deps = build
+       twine
+commands = python -m build --outdir {envtmpdir}/dist
+           python -c "import glob, subprocess, sys; subprocess.check_call(['twine', 'check', '--strict'] + sorted(glob.glob(sys.argv[1] + '/dist/*')))" {envtmpdir}
+
 [testenv:format]
 basepython = python3.13
 deps = {[testenv:isort]deps}
@@ -234,6 +246,7 @@ deps = {[testenv:flake8]deps}
        {[testenv:pydocstyle]deps}
        {[testenv:pylint_tests]deps}
        {[testenv:codespell]deps}
+       {[testenv:twine_check]deps}
 commands = {[testenv:compile]commands}
 	   {[testenv:flake8]commands}
            {[testenv:mypy]commands}


### PR DESCRIPTION
For final README.rst and packaging metadata linting
